### PR TITLE
remove unused methods from kii_json.h.

### DIFF
--- a/kii/kii_json.c
+++ b/kii/kii_json.c
@@ -34,7 +34,7 @@ static int prv_jsmn_token_num(const char* json_string, size_t json_string_len)
     return jsmn_parse(&parser, json_string, json_string_len, NULL, 0);
 }
 
-int prv_kii_jsmn_get_tokens(
+static int prv_kii_jsmn_get_tokens(
         kii_t* kii,
         const char* json_string,
         size_t json_string_len,
@@ -75,7 +75,7 @@ int prv_kii_jsmn_get_tokens(
     return ret;
 }
 
-int prv_kii_jsmn_get_value(
+static int prv_kii_jsmn_get_value(
         const char* json_string,
         size_t json_string_len,
         const jsmntok_t* tokens,

--- a/kii/kii_json.h
+++ b/kii/kii_json.h
@@ -58,20 +58,4 @@ kii_json_parse_result_t kii_json_read_object(
         size_t json_string_len,
         kii_json_field_t* fields);
 
-// TODO: remove this after new api is implemented..
-int prv_kii_jsmn_get_tokens(
-        kii_t* kii,
-        const char* json_string,
-        size_t json_string_len,
-        jsmntok_t* tokens,
-        size_t token_num);
-
-// TODO: remove this after new api is implemented.
-int prv_kii_jsmn_get_value(
-        const char* json_string,
-        size_t json_string_len,
-        const jsmntok_t* tokens,
-        const char* name,
-        jsmntok_t** out_token);
-
 #endif


### PR DESCRIPTION
kii_json.hから要らない関数定義を削除しました。マージをお願いします。

これをしないと #22 の修正でコンパイルエラー(jsmn.hのincludeを消したため)となります。
消した関数定義のために本来ならkii_json.h側にjsmn.hのincludeがあるべきの所が書かれていないためエラーとなります。
