### PR TITLE
typo is fixed kii_object_downlad_body to kii_object_download_body.

### DIFF
--- a/Linux/example.c
+++ b/Linux/example.c
@@ -216,7 +216,7 @@ int main(int argc, char** argv)
                 break;
             case 10:
                 printf("download body in multiple peces\n");
-                ret = kii_object_download_body(&kii, EX_OBJECT_ID, &bucket, 0, 
+                ret = kii_object_download_body(&kii, &bucket, EX_OBJECT_ID, 0, 
                         strlen(EX_BODY_DATA), &actual_length, &total_length);
                 if(ret == 0) {
                     printf("success!\n");

--- a/MTK/LinkIt_ONE/libraries/kii/example.c
+++ b/MTK/LinkIt_ONE/libraries/kii/example.c
@@ -180,7 +180,7 @@ int kiiDemo_test(char *buf)
         logger_cb("failed!\n");
     }
     logger_cb("download body in multiple peces\n");
-    ret = kii_object_download_body(&kii, EX_OBJECT_ID, &bucket, 0, 
+    ret = kii_object_download_body(&kii, &bucket, EX_OBJECT_ID, 0, 
     strlen(EX_BODY_DATA), &actual_length, &total_length);
     if(ret == 0) {
         logger_cb("success!\n");

--- a/TI/CC3200/wlan_station/kii/example.c
+++ b/TI/CC3200/wlan_station/kii/example.c
@@ -178,7 +178,7 @@ int kiiDemo_test(void)
         UART_PRINT("failed!\r\n");
     }
     UART_PRINT("download body in multiple peces\r\n");
-    ret = kii_object_download_body(&kii, EX_OBJECT_ID, &bucket, 0, 
+    ret = kii_object_download_body(&kii, &bucket, EX_OBJECT_ID, 0, 
     strlen(EX_BODY_DATA), &actual_length, &total_length);
     if(ret == 0) {
         UART_PRINT("success!\r\n");

--- a/WinnerMicro/HED10W07SN/Src/Kii/example.c
+++ b/WinnerMicro/HED10W07SN/Src/Kii/example.c
@@ -179,7 +179,7 @@ int kiiDemo_test(char *buf)
         printf("failed!\n");
     }
     printf("download body in multiple peces\n");
-    ret = kii_object_download_body(&kii, EX_OBJECT_ID, &bucket, 0, 
+    ret = kii_object_download_body(&kii, &bucket, EX_OBJECT_ID, 0, 
     strlen(EX_BODY_DATA), &actual_length, &total_length);
     if(ret == 0) {
         printf("success!\n");

--- a/kii/kii.h
+++ b/kii/kii.h
@@ -305,8 +305,8 @@ int kii_object_download_body_at_once(
  */
 int kii_object_download_body(
 		kii_t* kii,
-		const char* object_id,
 		const kii_bucket_t* bucket,
+		const char* object_id,
 		unsigned int position,
 		unsigned int length,
 		unsigned int* out_actual_length,

--- a/kii/kii_object.c
+++ b/kii/kii_object.c
@@ -566,8 +566,8 @@ exit:
 
 int kii_object_download_body(
         kii_t* kii,
-        const char* object_id,
         const kii_bucket_t* bucket,
+        const char* object_id,
         unsigned int position,
         unsigned int length,
         unsigned int* out_actual_length,


### PR DESCRIPTION
I found function named `kii_object_downlad_body`. I think `kii_object_download_body` is correct.
This is public function. If this function name is changed, it can be affected to applications.

Can we change this function name?

Related issue: #35 
