### PR TITLE
Use new core api

### DIFF
--- a/kii-core/kii_core.c
+++ b/kii-core/kii_core.c
@@ -904,6 +904,28 @@ kii_core_thing_authentication(kii_core_t* kii,
     return KIIE_OK;
 }
 
+    kii_error_code_t
+kii_core_thing_authentication_with_body(
+        kii_core_t* kii,
+        const char* body)
+{
+    kii_error_code_t result;
+
+    prv_set_auth_path(kii);
+    result = prv_http_request(
+            kii,
+            "POST",
+            kii->_http_request_path,
+            "application/json",
+            NULL,
+            NULL,
+            body);
+    if (result == KIIE_OK) {
+        kii->_state = KII_STATE_READY;
+    }
+
+    return result;
+}
 
     kii_error_code_t
 kii_core_create_new_object(

--- a/kii-core/kii_core.h
+++ b/kii-core/kii_core.h
@@ -498,6 +498,10 @@ kii_core_register_thing(kii_core_t* kii,
  * "_thingType" fields.  after this method succeeded, state of SDK
  * becomes KII_STATE_READY.<br> execute kii_core_run() to send the request
  * to Kii Cloud.
+ *
+ * vendor_thing_id, password and thing_type must be escaped in JSON
+ * manner. http://www.json.org/
+ *
  * @return result of preparation.
  * @param [in] kii SDK object.
  * @param [in] vendor_thing_id the thing identifier given by vendor.
@@ -515,6 +519,10 @@ kii_core_register_thing_with_id(
 /** prepare request of thing authentication.
  * after this method succeeded, state of SDK becomes KII_STATE_READY.<br>
  * execute kii_core_run() to send the request to Kii Cloud.
+ *
+ * vendor_thing_id and password must be escaped in JSON
+ * manner. http://www.json.org/
+ *
  * @return result of preparation.
  * @param [in] kii SDK object.
  * @param [in] vendor_thing_id thing id given by vendor on registration.
@@ -524,6 +532,18 @@ kii_error_code_t
 kii_core_thing_authentication(kii_core_t* kii,
         const char* vendor_thing_id,
         const char* password);
+
+/** prepare request of thing authentication with http body.
+ * after this method succeeded, state of SDK becomes KII_STATE_READY.<br>
+ * execute kii_core_run() to send the request to Kii Cloud.
+ *
+ * @return result of preparation.
+ * @param [in] kii SDK object.
+ * @param [in] body body of authentication request.
+ */
+kii_error_code_t
+kii_core_thing_authentication_with_body(kii_core_t* kii,
+        const char* body);
 
 /** prepare request of create object.
  * after this method succeeded, state of SDK becomes KII_STATE_READY.<br>

--- a/kii-core/tests/large_test/kii_test.cc
+++ b/kii-core/tests/large_test/kii_test.cc
@@ -70,6 +70,36 @@ TEST(kiiTest, authenticate)
     ASSERT_TRUE(strstr(kii.response_body, "\"access_token\"") != NULL);
 }
 
+TEST(kiiTest, authenticate_with_body)
+{
+    kii_error_code_t core_err;
+    kii_state_t state;
+    char buffer[4096];
+    kii_core_t kii;
+
+    init(&kii, buffer, 4096);
+
+    strcpy(kii.author.author_id, "");
+    strcpy(kii.author.access_token, "");
+    kii.response_code = 0;
+
+    core_err = kii_core_thing_authentication_with_body(&kii,
+            "{\"username\":\"VENDOR_THING_ID:1426830900\",\"password\":\"1234\"}");
+    ASSERT_EQ(KIIE_OK, core_err);
+
+    do {
+        core_err = kii_core_run(&kii);
+        state = kii_core_get_state(&kii);
+    } while (state != KII_STATE_IDLE);
+
+    ASSERT_EQ(KIIE_OK, core_err);
+    ASSERT_EQ(200, kii.response_code);
+    ASSERT_STRNE("", kii.response_body);
+
+    ASSERT_TRUE(strstr(kii.response_body, "\"id\"") != NULL);
+    ASSERT_TRUE(strstr(kii.response_body, "\"access_token\"") != NULL);
+}
+
 TEST(kiiTest, register)
 {
     kii_error_code_t core_err;

--- a/kii/kii.h
+++ b/kii/kii.h
@@ -122,6 +122,17 @@ int kii_thing_authenticate(
 		const char* vendor_thing_id,
 		const char* password);
 
+/** Authorize thing with request body.
+ *  After the authentication, access token is used to call APIs access to
+ *  Kii Cloud so that the thing can access private data.
+ *  \param [inout] kii sdk instance.
+ *  \param [in] body body of authentication request.
+ *  \return 0:success, -1: failure
+ */
+int kii_thing_authenticate_with_body(
+		kii_t* kii,
+		const char* body);
+
 /** Register new thing
  *  After the registtration, access token is used to call APIs access to
  *  Kii Cloud so that the thing can access private data.

--- a/tests/large_test/kii_test.cc
+++ b/tests/large_test/kii_test.cc
@@ -61,6 +61,26 @@ TEST(kiiTest, authenticate)
     ASSERT_STRNE("", kii.kii_core.author.access_token);
 }
 
+TEST(kiiTest, authenticate_with_body)
+{
+    int ret = -1;
+    char buffer[4096];
+    kii_t kii;
+
+    init(&kii, buffer, 4096);
+
+    strcpy(kii.kii_core.author.author_id, "");
+    strcpy(kii.kii_core.author.access_token, "");
+    kii.kii_core.response_code = 0;
+    ret = kii_thing_authenticate_with_body(&kii,
+            "{\"username\":\"VENDOR_THING_ID:1426830900\",\"password\":\"1234\"}");
+
+    ASSERT_EQ(0, ret);
+    ASSERT_EQ(200, kii.kii_core.response_code);
+    ASSERT_STRNE("", kii.kii_core.author.author_id);
+    ASSERT_STRNE("", kii.kii_core.author.access_token);
+}
+
 TEST(kiiTest, register)
 {
     int ret = -1;


### PR DESCRIPTION
kii-coreに新しく追加されたkii_core_thing_authentication_with_bodyに対応するAPIの追加とテストを実装しました。
現時点でCore側のPRが未マージなのでサブモジュールの更新はしていないので注意してください。

PR: https://github.com/KiiPlatform/KiiThingSDK-Embedded-Core/pull/73
