### PR TITLE
remove warnings in VC.

### DIFF
--- a/kii/kii_mqtt.c
+++ b/kii/kii_mqtt.c
@@ -44,9 +44,9 @@ int kiiMQTT_decode(char* buf, int* value)
 
 int kiiMQTT_connect(kii_t* kii, kii_mqtt_endpoint_t* endpoint, unsigned short keepAliveInterval)
 {
-    int i;
-    int j;
-    int k;
+    size_t i;
+    size_t j;
+    size_t k;
     kii_socket_code_t sock_err;
     size_t actual_length;
 
@@ -177,9 +177,9 @@ int kiiMQTT_connect(kii_t* kii, kii_mqtt_endpoint_t* endpoint, unsigned short ke
 
 int kiiMQTT_subscribe(kii_t* kii, const char* topic, enum QoS qos)
 {
-    int i;
-    int j;
-    int k;
+    size_t i;
+    size_t j;
+    size_t k;
     size_t actual_length = 0;
     kii_socket_code_t sock_err;
 

--- a/kii/kii_push.c
+++ b/kii/kii_push.c
@@ -325,9 +325,9 @@ static void* kiiPush_recvMsgTask(void* sdata)
     int remainingLen;
     int byteLen;
     int topicLen;
-    int totalLen;
+    size_t totalLen;
     char* p;
-    int bytes = 0;
+    size_t bytes = 0;
     size_t rcvdCounter = 0;
     KII_PUSH_RECEIVED_CB callback;
     kiiPush_endpointState_e endpointState;


### PR DESCRIPTION
VisualStudio2015環境で警告を削除しました。

修正後Cygwin、Mac環境でここに関する警告が出ないことは確認済みです。

Issue: #95 