### PR TITLE
socket is checked whether the socket is readable or not.

### DIFF
--- a/kii/kii_push.c
+++ b/kii/kii_push.c
@@ -379,7 +379,11 @@ static void* kiiPush_recvMsgTask(void* sdata)
             M_KII_LOG(kii->kii_core.logger_cb("readPointer: %d\r\n", kii->mqtt_buffer + bytes));
 
             rcvdCounter = 0;
-            kii->mqtt_socket_recv_cb(&kii->mqtt_socket_context, kii->mqtt_buffer, 2, &rcvdCounter);
+            if (kii->mqtt_socket_recv_cb(
+                    &kii->mqtt_socket_context, kii->mqtt_buffer, 2,
+                    &rcvdCounter) == KII_SOCKETC_AGAIN) {
+                continue;
+            }
             if(rcvdCounter == 2)
             {
                 if((kii->mqtt_buffer[0] & 0xf0) == 0x30)


### PR DESCRIPTION
pahoを参考にselectを使って、ソケットが受信可能かをチェックするようにしました。

selectを使うことで、受信可能なデータが存在するかをチェックできます。なのでタイムアウトを迎えた時に、受信可能なデータがないだけならば、もう一回まわす形にしています。

この形ならば、データが存在しないのではなく、実際に失敗した場合に即座に再接続を試みるようになります。

関連issue #102 