### PR TITLE
x-kii-sdk header is inserted all requests.

### DIFF
--- a/kii-core/kii_core.c
+++ b/kii-core/kii_core.c
@@ -500,7 +500,50 @@ prv_set_thing_register_path(kii_core_t* kii)
             kii->app_id);
 }
 
-    static kii_error_code_t 
+    static kii_http_client_code_t
+prv_set_kii_default_header(kii_core_t* kii)
+{
+    kii_http_client_code_t result = KII_HTTPC_FAIL;
+
+    result = prv_kii_http_set_header(
+            kii,
+            "host",
+            kii->app_host);
+    if (result != KII_HTTPC_OK) {
+        M_KII_LOG(M_REQUEST_HEADER_CB_FAILED);
+        return result;
+    }
+
+    result = prv_kii_http_set_header(
+            kii,
+            "x-kii-appid",
+            kii->app_id);
+    if (result != KII_HTTPC_OK) {
+        M_KII_LOG(M_REQUEST_HEADER_CB_FAILED);
+        return result;
+    }
+
+    result = prv_kii_http_set_header(
+            kii,
+            "x-kii-appkey",
+            kii->app_key);
+    if (result != KII_HTTPC_OK) {
+        M_KII_LOG(M_REQUEST_HEADER_CB_FAILED);
+        return result;
+    }
+    result = prv_kii_http_set_header(
+            kii,
+            "x-kii-sdk",
+            kii->_sdk_info);
+    if (result != KII_HTTPC_OK) {
+        M_KII_LOG(M_REQUEST_HEADER_CB_FAILED);
+        return result;
+    }
+
+    return KII_HTTPC_OK;
+}
+
+    static kii_error_code_t
 prv_http_request_line_and_headers(
         kii_core_t* kii,
         const char* method,
@@ -516,36 +559,7 @@ prv_http_request_line_and_headers(
         return KIIE_FAIL;
     }
 
-    result = prv_kii_http_set_header(
-            kii,
-            "host",
-            kii->app_host);
-    if (result != KII_HTTPC_OK) {
-        M_KII_LOG(M_REQUEST_HEADER_CB_FAILED);
-        return KIIE_FAIL;
-    }
-
-    result = prv_kii_http_set_header(
-            kii,
-            "x-kii-appid",
-            kii->app_id);
-    if (result != KII_HTTPC_OK) {
-        M_KII_LOG(M_REQUEST_HEADER_CB_FAILED);
-        return KIIE_FAIL;
-    }
-
-    result = prv_kii_http_set_header(
-            kii,
-            "x-kii-appkey",
-            kii->app_key);
-    if (result != KII_HTTPC_OK) {
-        M_KII_LOG(M_REQUEST_HEADER_CB_FAILED);
-        return KIIE_FAIL;
-    }
-    result = prv_kii_http_set_header(
-            kii,
-            "x-kii-sdk",
-            kii->_sdk_info);
+    result = prv_set_kii_default_header(kii);
     if (result != KII_HTTPC_OK) {
         M_KII_LOG(M_REQUEST_HEADER_CB_FAILED);
         return KIIE_FAIL;
@@ -1403,32 +1417,7 @@ kii_core_api_call(
         return KIIE_FAIL;
     }
 
-    /* set host */
-    result = prv_kii_http_set_header(
-            kii,
-            "host",
-            kii->app_host
-            );
-    if (result != KII_HTTPC_OK) {
-        M_KII_LOG(M_REQUEST_LINE_CB_FAILED);
-        goto exit;
-    }
-
-    /* set app id */
-    result = prv_kii_http_set_header(
-            kii,
-            "x-kii-appid",
-            kii->app_id);
-    if (result != KII_HTTPC_OK) {
-        M_KII_LOG(M_REQUEST_HEADER_CB_FAILED);
-        goto exit;
-    }
-
-    /* set app key */
-    result = prv_kii_http_set_header(
-            kii,
-            "x-kii-appkey",
-            kii->app_key);
+    result = prv_set_kii_default_header(kii);
     if (result != KII_HTTPC_OK) {
         M_KII_LOG(M_REQUEST_HEADER_CB_FAILED);
         goto exit;
@@ -1590,22 +1579,11 @@ kii_core_api_call_start(
         return KIIE_FAIL;
     }
 
-    /* set default headers. */
-    if (prv_kii_http_set_header(kii, "host",
-                    kii->app_host) != KII_HTTPC_OK) {
+    if (prv_set_kii_default_header(kii) != KII_HTTPC_OK) {
         M_KII_LOG(M_REQUEST_HEADER_CB_FAILED);
         return KIIE_FAIL;
     }
-    if (prv_kii_http_set_header(kii, "x-kii-appid",
-                    kii->app_id) != KII_HTTPC_OK) {
-        M_KII_LOG(M_REQUEST_HEADER_CB_FAILED);
-        return KIIE_FAIL;
-    }
-    if (prv_kii_http_set_header(kii, "x-kii-appkey",
-                    kii->app_key) != KII_HTTPC_OK) {
-        M_KII_LOG(M_REQUEST_HEADER_CB_FAILED);
-        return KIIE_FAIL;
-    }
+
     if (prv_kii_http_set_header(kii, "content-type",
                     content_type) != KII_HTTPC_OK) {
         M_KII_LOG(M_REQUEST_HEADER_CB_FAILED);


### PR DESCRIPTION
x-kii-sdkヘッダがリクエストに挿入されないパスがありました。
thing-if-ThingSDKのテストで発見しました。

修正し、thing-if-ThingSDKでもx−kii-sdkが出るように修正しました。

リクエストの`x-app-id`などデフォルトで必要なHTTPヘッダを挿入している部分が3箇所ありました。

1. `prv_http_request_line_and_headers`
1. `kii_core_api_call`
1. `kii_core_api_call_start`

これら全てにx-kii-sdkヘッダを追加しなければいけなかったのですが、1にのみ追加してあり、他は追加していませんでした。

今後のこともかんがえて、host、x-app-id、x-app-key、x-kii-sdkヘッダをまとめて入れる関数を作り、それぞれの関数はその関数を呼び出すようにしました。