### PR TITLE
Content length

### DIFF
--- a/kii-core/kii_core.c
+++ b/kii-core/kii_core.c
@@ -1584,10 +1584,12 @@ kii_core_api_call_start(
         return KIIE_FAIL;
     }
 
-    if (prv_kii_http_set_header(kii, "content-type",
-                    content_type) != KII_HTTPC_OK) {
-        M_KII_LOG(M_REQUEST_HEADER_CB_FAILED);
-        return KIIE_FAIL;
+    if (content_type != NULL) {
+        if (prv_kii_http_set_header(kii, "content-type",
+                        content_type) != KII_HTTPC_OK) {
+            M_KII_LOG(M_REQUEST_HEADER_CB_FAILED);
+            return KIIE_FAIL;
+        }
     }
     if (set_authentication_header == KII_TRUE) {
         if (prv_kii_core_set_authorization_header(kii) != KII_HTTPC_OK) {
@@ -1632,10 +1634,12 @@ kii_error_code_t kii_core_api_call_end(kii_core_t* kii)
     }
 
     /* set content length. */
-    if (prv_kii_core_http_set_content_length_header(kii,
-                    kii->_content_length) != KII_HTTPC_OK) {
-        M_KII_LOG(M_REQUEST_HEADER_CB_FAILED);
-        return KIIE_FAIL;
+    if (kii->_content_length > 0) {
+        if (prv_kii_core_http_set_content_length_header(kii,
+                        kii->_content_length) != KII_HTTPC_OK) {
+            M_KII_LOG(M_REQUEST_HEADER_CB_FAILED);
+            return KIIE_FAIL;
+        }
     }
 
     /* set reday. */

--- a/kii-core/kii_core.h
+++ b/kii-core/kii_core.h
@@ -786,7 +786,8 @@ kii_core_api_call(
  * @param [in] kii SDK object.
  * @param [in] http_method method of http request.
  * @param [in] resource_path resource path of http request.
- * @param [in] content_type content type of http_body.
+ * @param [in] content_type content type of http_body. If the request
+ * has no http body such as GET method, you can set NULL.
  * @param [in] set_authentication_header a flag to set or not
  * authentication header.
  * @return result of preparation. if KIIE_OK, preparation is


### PR DESCRIPTION
@kishimotokii san has claimed kii_core_api series functions does not accept no content length request such as GET method.

To adapt no content length and no content type request, I fixed `kii_core_api_call_start()` and `kii_core_api_call_end()` methods.