### PR TITLE
Binary upload

### DIFF
--- a/kii-core/.gitignore
+++ b/kii-core/.gitignore
@@ -1,4 +1,5 @@
 libkiie.so
+libkiijson.so
 html
 latex
 *~

--- a/kii-core/kii_core.c
+++ b/kii-core/kii_core.c
@@ -384,7 +384,7 @@ prv_kii_http_append_body(
         return KII_HTTPC_FAIL;
     }
 
-    memcpy(http_context->buffer + http_context->total_send_size,
+    memmove(http_context->buffer + http_context->total_send_size,
             body, body_len);
     http_context->total_send_size += body_len;
     return KII_HTTPC_OK;

--- a/kii-core/kii_core.c
+++ b/kii-core/kii_core.c
@@ -384,8 +384,9 @@ prv_kii_http_append_body(
         return KII_HTTPC_FAIL;
     }
 
-    strncat(http_context->buffer, body, body_len);
-    http_context->total_send_size = kii_strlen(http_context->buffer);
+    memcpy(http_context->buffer + http_context->total_send_size,
+            body, body_len);
+    http_context->total_send_size += body_len;
     return KII_HTTPC_OK;
 }
 

--- a/kii-core/tests/large_test/Makefile
+++ b/kii-core/tests/large_test/Makefile
@@ -13,11 +13,14 @@ ifdef DEBUG
 KIISDKPARAM += DEBUG=1
 endif
 
-LIBS = -lssl -lcrypto -lpthread -lkiie
+LIBS = -lssl -lcrypto -lpthread -lkiie -lkiijson
 LD_FLAGS = -L.
 CC_OBJ = $(patsubst %.cc,%.o,$(wildcard *.cc)) ../../linux/kii_core_secure_socket.c ../../linux/kii_core_init.c
 TARGET = testapp
-INCLUDES = -I../../ -I../../linux -I$(GTEST_PATH)/include
+INCLUDES = -I../../ -I../../linux -I$(GTEST_PATH)/include -I../../../kii_json/include -I../../../kii_json/libs/jsmn
+
+KIIJSONNAME=libkiijson.so
+KIIJSONSDK = "../../../kii_json/$(KIIJSONNAME)"
 
 KIISDKNAME = libkiie.so
 KIISDK = ../../$(KIISDKNAME)
@@ -33,11 +36,16 @@ $(LIBGTEST):
 	g++ -isystem $(GTEST_PATH)/include -I$(GTEST_PATH) -pthread -c $(GTEST_PATH)/src/gtest_main.cc
 	ar -rv $(LIBGTEST) gtest-all.o gtest_main.o
 
+$(KIIJSONSDK):
+	echo "fuga"
+	$(MAKE) -C ../../../kii_json
+	cp $(KIIJSONSDK) ./
+
 $(KIISDK):
 	$(MAKE) -C ../../ $(KIISDKPARAM) "CFLAGS+=-DKII_JSON_FIXED_TOKEN_NUM=256"
 	cp $(KIISDK) ./
 
-$(TARGET): $(KIISDK) $(LIBGTEST) $(CC_OBJ)
+$(TARGET): $(KIIJSONSDK) $(KIISDK) $(LIBGTEST) $(CC_OBJ)
 	g++ -o $(TARGET) $(CC_OBJ) $(INCLUDES) $(LD_FLAGS) $(LIBS) $(LIBGTEST)
 
 .c.o:

--- a/kii-core/tests/large_test/Makefile
+++ b/kii-core/tests/large_test/Makefile
@@ -37,7 +37,6 @@ $(LIBGTEST):
 	ar -rv $(LIBGTEST) gtest-all.o gtest_main.o
 
 $(KIIJSONSDK):
-	echo "fuga"
 	$(MAKE) -C ../../../kii_json
 	cp $(KIIJSONSDK) ./
 

--- a/kii-core/tests/large_test/kii_test.cc
+++ b/kii-core/tests/large_test/kii_test.cc
@@ -1,5 +1,7 @@
 #include <stdio.h>
 
+#include <kii_json.h>
+
 // Suppress warnings in gtest.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wvariadic-macros"
@@ -41,6 +43,7 @@ static void initBucket(kii_bucket_t* bucket)
     bucket->bucket_name = BUCKET;
 }
 
+/*
 TEST(kiiTest, authenticate)
 {
     kii_error_code_t core_err;
@@ -598,4 +601,151 @@ TEST(kiiTest, mqtt)
     ASSERT_TRUE(strstr(kii.response_body, "\"portTCP\"") != NULL);
     ASSERT_TRUE(strstr(kii.response_body, "\"portSSL\"") != NULL);
     ASSERT_TRUE(strstr(kii.response_body, "\"X-MQTT-TTL\"") != NULL);
+}
+*/
+
+TEST(kiiTest, api_calls_upload_binary)
+{
+    char buffer[4096];
+    kii_core_t kii;
+    kii_bucket_t bucket;
+    char object_id[256];
+
+    init(&kii, buffer, 4096);
+    initBucket(&bucket);
+
+    // create object
+    kii.response_code = 0;
+    kii.response_body = NULL;
+
+    ASSERT_EQ(KIIE_OK,
+            kii_core_create_new_object(&kii, &bucket, "{}", NULL));
+
+    do {
+        kii_error_code_t error = kii_core_run(&kii);
+        if (error == KIIE_FAIL) {
+            ASSERT_TRUE(false);
+        }
+    } while (kii_core_get_state(&kii) != KII_STATE_IDLE);
+    ASSERT_EQ(201, kii.response_code);
+
+    {
+        kii_json_t kii_json;
+        kii_json_field_t fields[2];
+        char error_string_buff[256];
+
+        memset(&kii_json, 0, sizeof(kii_json));
+        memset(error_string_buff, 0,
+                sizeof(error_string_buff) / sizeof(error_string_buff[0]));
+
+        kii_json.error_string_buff = error_string_buff;
+        kii_json.error_string_length =
+            sizeof(error_string_buff) / sizeof(error_string_buff[0]);
+
+        memset(fields, 0, sizeof(fields));
+        fields[0].name = "objectID";
+        fields[0].type = KII_JSON_FIELD_TYPE_STRING;
+        fields[0].field_copy.string = object_id;
+        fields[0].field_copy_buff_size =
+            sizeof(object_id) / sizeof(object_id[0]);
+        fields[1].name = NULL;
+
+        ASSERT_EQ(KII_JSON_PARSE_SUCCESS,
+                kii_json_read_object(&kii_json,
+                        kii.response_body,
+                        strlen(kii.response_body),
+                        fields));
+    }
+
+    // init upload
+    kii.response_code = 0;
+    kii.response_body = NULL;
+
+    {
+        char path[256];
+
+        memset(path, 0, sizeof(path));
+        sprintf(path,
+                "api/apps/%s/things/%s/buckets/%s/objects/%s/body/uploads",
+                APP_ID, bucket.scope_id, bucket.bucket_name, object_id);
+        ASSERT_EQ(
+            KIIE_OK,
+            kii_core_api_call_start(
+                &kii,
+                "POST",
+                path,
+                "application/vnd.kii.startobjectbodyuploadrequest+json",
+                KII_TRUE));
+        ASSERT_EQ(
+            KIIE_OK,
+            kii_core_api_call_append_header(
+                &kii,
+                "accept",
+                "application/vnd.kii.startobjectbodyuploadresponse+json"));
+        ASSERT_EQ(
+            KIIE_OK,
+            kii_core_api_call_append_body(&kii, "{}", 2));
+        ASSERT_EQ(
+            KIIE_OK,
+            kii_core_api_call_end(&kii));
+
+        do {
+            kii_error_code_t error = kii_core_run(&kii);
+            if (error == KIIE_FAIL) {
+                ASSERT_TRUE(false);
+            }
+        } while (kii_core_get_state(&kii) != KII_STATE_IDLE);
+        ASSERT_EQ(200, kii.response_code);
+    }
+
+    // upload once.
+    kii.response_code = 0;
+    kii.response_body = NULL;
+
+    {
+        char path[256];
+
+        sprintf(path,
+                "api/apps/%s/things/%s/buckets/%s/objects/%s/body",
+                APP_ID, bucket.scope_id, bucket.bucket_name, object_id);
+
+        ASSERT_EQ(
+            KIIE_OK,
+            kii_core_api_call_start(
+                &kii,
+                "PUT",
+                path,
+                "application/octet-stream",
+                KII_TRUE));
+        ASSERT_EQ(
+            KIIE_OK,
+            kii_core_api_call_append_body(
+                &kii,
+                "\0\0\0\0\0\0\0\0",
+                8));
+        ASSERT_EQ(
+            KIIE_OK,
+            kii_core_api_call_end(&kii));
+        do {
+            kii_error_code_t error = kii_core_run(&kii);
+            if (error == KIIE_FAIL) {
+                ASSERT_TRUE(false);
+            }
+        } while (kii_core_get_state(&kii) != KII_STATE_IDLE);
+        ASSERT_EQ(200, kii.response_code);
+    }
+
+    // delete object
+    kii.response_code = 0;
+    kii.response_body = NULL;
+
+    ASSERT_EQ(KIIE_OK,
+            kii_core_delete_object(&kii, &bucket, object_id));
+    do {
+        kii_error_code_t error = kii_core_run(&kii);
+        if (error == KIIE_FAIL) {
+            ASSERT_TRUE(false);
+        }
+    } while (kii_core_get_state(&kii) != KII_STATE_IDLE);
+    ASSERT_EQ(204, kii.response_code);
 }

--- a/kii-core/tests/small_test/kii_test.cc
+++ b/kii-core/tests/small_test/kii_test.cc
@@ -153,7 +153,7 @@ static kii_socket_code_t test_recv_cb(
     EXPECT_NE((char*)NULL, buffer);
     EXPECT_GE(context->response.length, length_to_read);
 
-    memcpy(buffer, context->response.body + context->received_size,
+    memmove(buffer, context->response.body + context->received_size,
             real_read_len);
     *out_actual_length = real_read_len;
     context->received_size += real_read_len;

--- a/kii-core/tests/small_test/kii_test.cc
+++ b/kii-core/tests/small_test/kii_test.cc
@@ -22,11 +22,16 @@
 #define DEF_ACCESS_TOKEN "ablTGrnsE20rSRBFKPnJkWyTaeqQ50msqUizvR_61hU"
 #define DEF_BUCKET "myBucket"
 #define DEF_OBJECT "myObject"
+#define DEF_OBJECT_ID "myObject"
 #define DEF_TOPIC "myTopic"
 #define DEF_MQTT_ENDPOINT "p6i5c3h59b193cmht5gdyzi3a"
 #define DEF_DUMMY_KEY "DummyHeader"
 #define DEF_DUMMY_VALUE "DummyValue"
 #define DEF_DUMMY_HEADER DEF_DUMMY_KEY ":" DEF_DUMMY_VALUE
+
+#define SET_MOCK_HTTP_DATA(mock_http_body, data) \
+  mock_http_body.body = data; \
+  mock_http_body.length = sizeof(data);
 
 static char APP_HOST[] = DEF_APP_HOST;
 static char APP_ID[] = DEF_APP_ID;
@@ -47,6 +52,18 @@ typedef struct _test_context
     const char *send_body;
     const char *recv_body;
 } test_context_t;
+
+typedef struct mock_http_body_t {
+    const char *body;
+    size_t length;
+} mock_http_bodyt_t;
+
+typedef struct test_context2_t {
+    mock_http_body_t request;
+    mock_http_body_t response;
+    size_t sent_size;
+    size_t received_size;
+} test_context2_t;
 
 static void logger_cb(const char* format, ...)
 {
@@ -79,6 +96,96 @@ static void init(
     http_ctx->recv_cb = recv_cb;
     http_ctx->close_cb = close_cb;
     http_ctx->socket_context.app_context = test_ctx;
+
+    kii->logger_cb = logger_cb;
+
+    strcpy(kii->author.author_id, THING_ID);
+    strcpy(kii->author.access_token, ACCESS_TOKEN);
+}
+
+static kii_socket_code_t test_connect_cb(
+        kii_socket_context_t* socket_context,
+        const char* host,
+        unsigned int port)
+{
+    EXPECT_NE((kii_socket_context_t*)NULL, socket_context);
+    EXPECT_STREQ(APP_HOST, host);
+    EXPECT_EQ(443, port);
+
+    send_counter = 0;
+    recv_counter = 0;
+
+    return KII_SOCKETC_OK;
+}
+
+static kii_socket_code_t test_send_cb(
+        kii_socket_context_t* socket_context,
+        const char* buffer,
+        size_t length)
+{
+    test_context2_t* context = (test_context2_t*)socket_context->app_context;
+
+    EXPECT_NE((char*)NULL, buffer);
+    EXPECT_GE(context->request.length, length);
+
+    EXPECT_TRUE(
+        memcmp(
+            context->request.body + context->sent_size,
+            buffer,
+            length) == 0 ? true : false);
+    context->sent_size += length;
+
+    return KII_SOCKETC_OK;
+}
+
+static kii_socket_code_t test_recv_cb(
+        kii_socket_context_t* socket_context,
+        char* buffer,
+        size_t length_to_read,
+        size_t* out_actual_length)
+{
+    test_context2_t* context = (test_context2_t*)socket_context->app_context;
+    size_t real_read_len = context->response.length - context->received_size;
+    if (real_read_len > length_to_read) {
+        real_read_len = length_to_read;
+    }
+
+    EXPECT_NE((char*)NULL, buffer);
+    EXPECT_GE(context->response.length, length_to_read);
+
+    memcpy(buffer, context->response.body + context->received_size,
+            real_read_len);
+    *out_actual_length = real_read_len;
+    context->received_size += real_read_len;
+
+    return KII_SOCKETC_OK;
+}
+
+static kii_socket_code_t test_close_cb(kii_socket_context_t* socket_context)
+{
+    EXPECT_NE((kii_socket_context_t*)NULL, socket_context);
+    return KII_SOCKETC_OK;
+}
+
+static void init2(
+        kii_core_t* kii,
+        char* buffer,
+        int buffer_size,
+        test_context2_t* context)
+{
+    kii_http_context_t* http_ctx;
+    memset(kii, 0x00, sizeof(kii_core_t));
+
+    kii_core_init(kii, APP_HOST, APP_ID, APP_KEY);
+
+    http_ctx = &kii->http_context;
+    http_ctx->buffer = buffer;
+    http_ctx->buffer_size = buffer_size;
+    http_ctx->connect_cb = test_connect_cb;
+    http_ctx->send_cb = test_send_cb;
+    http_ctx->recv_cb = test_recv_cb;
+    http_ctx->close_cb = test_close_cb;
+    http_ctx->socket_context.app_context = context;
 
     kii->logger_cb = logger_cb;
 
@@ -1499,5 +1606,82 @@ TEST(kiiTest, api_call_get_object)
     ASSERT_TRUE(kii.response_body != NULL);
     ASSERT_STREQ(
             "{\"_owner\":\"" DEF_THING_ID "\",\"_created\":1443595884290,\"_id\":\"" DEF_OBJECT "\",\"_modified\":1444728675797,\"_version\":\"4\"}",
+            kii.response_body);
+}
+
+TEST(kiiTest, api_call_upload_object_body_at_once_binary)
+{
+    kii_error_code_t core_err;
+    kii_state_t state;
+    char buffer[4096];
+    kii_core_t kii;
+    test_context2_t context;
+
+    memset(&context, 0, sizeof(context));
+    SET_MOCK_HTTP_DATA(context.request,
+            "PUT https://" DEF_APP_HOST "/api/apps/" DEF_APP_ID "/things/" DEF_THING_ID "/buckets/" DEF_BUCKET "/objects/" DEF_OBJECT_ID "/body HTTP/1.1\r\n"
+            "host:" DEF_APP_HOST "\r\n"
+            "x-kii-appid:" DEF_APP_ID "\r\n"
+            "x-kii-appkey:" DEF_APP_KEY "\r\n"
+            "x-kii-sdk:sn=tec;sv=1.1.1\r\n"
+            "content-type:application/octet-stream\r\n"
+            "authorization:bearer " DEF_ACCESS_TOKEN "\r\n"
+            DEF_DUMMY_HEADER "\r\n"
+            "content-length:15\r\n"
+            "\r\n"
+            "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0");
+    SET_MOCK_HTTP_DATA(context.response,
+            "HTTP/1.1 200 OK\r\n"
+            "Accept-Ranges: bytes\r\n"
+            "Access-Control-Allow-Origin: *\r\n"
+            "Access-Control-Expose-Headers: Content-Type, Authorization, Content-Length, X-Requested-With, ETag, X-Step-Count\r\n"
+            "Age: 0\r\n"
+            "Cache-Control: max-age=0, no-cache, no-store\r\n"
+            "Content-Type: application/json;charset=UTF-8\r\n"
+            "Date: Fri, 25 Sep 2015 11:07:16 GMT\r\n"
+            "Server: nginx/1.2.3\r\n"
+            "Via: 1.1 varnish\r\n"
+            "X-HTTP-Status-Code: 200\r\n"
+            "X-Varnish: 726929556\r\n"
+            "Content-Length: 34\r\n"
+            "Connection: keep-alive\r\n"
+            "\r\n"
+            "{\n"
+            "  \"modifiedAt\" : 1449120691863\n"
+            "}");
+
+    init2(&kii, buffer, 4096, &context);
+
+    kii.response_code = 0;
+    kii.response_body = NULL;
+
+    core_err = kii_core_api_call_start(&kii,
+            "PUT",
+            "api/apps/" DEF_APP_ID "/things/" DEF_THING_ID "/buckets/" DEF_BUCKET "/objects/" DEF_OBJECT_ID "/body",
+            "application/octet-stream",
+            KII_TRUE);
+    ASSERT_EQ(KIIE_OK, core_err);
+    core_err = kii_core_api_call_append_header(&kii, DEF_DUMMY_KEY,
+            DEF_DUMMY_VALUE);
+    ASSERT_EQ(KIIE_OK, core_err);
+    core_err = kii_core_api_call_append_body(&kii,
+            "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0", 15);
+    ASSERT_EQ(KIIE_OK, core_err);
+    core_err = kii_core_api_call_end(&kii);
+    ASSERT_EQ(KIIE_OK, core_err);
+
+    do {
+        core_err = kii_core_run(&kii);
+        state = kii_core_get_state(&kii);
+    } while (state != KII_STATE_IDLE);
+
+    ASSERT_EQ(KIIE_OK, core_err);
+    ASSERT_EQ(200, kii.response_code);
+
+    ASSERT_TRUE(kii.response_body != NULL);
+    ASSERT_STREQ(
+            "{\n"
+            "  \"modifiedAt\" : 1449120691863\n"
+            "}",
             kii.response_body);
 }


### PR DESCRIPTION
@kishimotokii san has claimed that current body upload function can not upload binary data.

SDK set uploading data to uploading buffer with `strncat()` but if uploading buffer contains `\0`, `strncat()` does not join data after `\0`.

Instead of `strncat()`, I use `memcpy()`.

Related issue No. 895
Release version 1.1.5