### PR TITLE
Type of upload data is changed.

### DIFF
--- a/kii-core/kii_core.c
+++ b/kii-core/kii_core.c
@@ -1397,7 +1397,7 @@ kii_core_api_call(
         kii_core_t* kii,
         const char* http_method,
         const char* resource_path,
-        const char* http_body,
+        const void* http_body,
         size_t body_size,
         const char* content_type,
         char* header,
@@ -1658,7 +1658,7 @@ kii_error_code_t kii_core_api_call_end(kii_core_t* kii)
 kii_error_code_t
 kii_core_api_call_append_body(
         kii_core_t* kii,
-        const char* body_data,
+        const void* body_data,
         size_t body_size)
 {
     if (prv_kii_http_append_body(kii, body_data, body_size) !=

--- a/kii-core/kii_core.h
+++ b/kii-core/kii_core.h
@@ -771,7 +771,7 @@ kii_core_api_call(
         kii_core_t* kii,
         const char* http_method,
         const char* resource_path,
-        const char* http_body,
+        const void* http_body,
         size_t body_size,
         const char* content_type,
         char* header,
@@ -815,7 +815,7 @@ kii_error_code_t kii_core_api_call_start(
  */
 kii_error_code_t kii_core_api_call_append_body(
         kii_core_t* kii,
-        const char* body_data,
+        const void* body_data,
         size_t body_size);
 
 /** append request header.

--- a/kii/kii.h
+++ b/kii/kii.h
@@ -489,7 +489,7 @@ int kii_api_call_start(
  */
 int kii_api_call_append_body(
         kii_t* kii,
-        const char* body_data,
+        const void* body_data,
         size_t body_size);
 
 /** append request header.

--- a/kii/kii.h
+++ b/kii/kii.h
@@ -260,7 +260,7 @@ int kii_object_upload_body_at_once(
 		const kii_bucket_t* bucket,
 		const char* object_id,
 		const char* body_content_type,
-		const char* data,
+		const void* data,
 		size_t data_length);
 
 /** Initiate chunked object body upload.
@@ -283,13 +283,13 @@ typedef struct kii_chunk_data_t {
 	/** content-type of the body */
 	char* body_content_type;
 	/** position of the chunk.(bytes count) */
-	unsigned int position;
+	size_t position;
 	/** length of the chunk */
-	unsigned int length;
+	size_t length;
 	/** total length of the body */
-	unsigned int total_length;
+	size_t total_length;
 	/** chunk data */
-	char* chunk;
+	void* chunk;
 } kii_chunk_data_t;
 
 /** Upload object body chunk by chunk.

--- a/kii/kii_call.c
+++ b/kii/kii_call.c
@@ -15,7 +15,7 @@ int kii_api_call_start(
 
 int kii_api_call_append_body(
         kii_t* kii,
-        const char* body_data,
+        const void* body_data,
         size_t body_size)
 {
     return kii_core_api_call_append_body(&(kii->kii_core), body_data,

--- a/kii/kii_object.c
+++ b/kii/kii_object.c
@@ -245,7 +245,7 @@ int kii_object_upload_body_at_once(
         const kii_bucket_t* bucket,
         const char* object_id,
         const char* body_content_type,
-        const char* data,
+        const void* data,
         size_t data_length)
 {
     int ret = -1;
@@ -395,11 +395,11 @@ int kii_object_upload_body(
     memset(content_range, 0x00, sizeof(content_range));
     strcpy(content_range, "Content-Range: ");
     strcat(content_range, "bytes=");
-    sprintf(content_range + strlen(content_range), "%d", chunk->position);
+    sprintf(content_range + strlen(content_range), "%lu", chunk->position);
     strcat(content_range, "-");
-    sprintf(content_range + strlen(content_range), "%d", chunk->position+ chunk->length- 1);
+    sprintf(content_range + strlen(content_range), "%lu", chunk->position+ chunk->length- 1);
     strcat(content_range, "/");
-    sprintf(content_range + strlen(content_range), "%d", chunk->total_length);
+    sprintf(content_range + strlen(content_range), "%lu", chunk->total_length);
 
     core_err = kii_core_api_call(
             &kii->kii_core,


### PR DESCRIPTION
アップロードAPIの修正です。最初の話では、アップロード対象のbodyがcharポインタだと、文字列しか受けつらないように見えるから、わかりづらいという話から始まりました。なのでvoidポインタに修正しました。

アプリケーションは修正不要で、わかりやすくなっていると思います。これはこれで悪くない方法かと思います。kii_byte型などの新しい型を定義した方がよりわかりやすくなると思います。

Related issue: No913.
Release version: 1.1.6