### PR TITLE
Body upload with reader

### DIFF
--- a/kii/kii.h
+++ b/kii/kii.h
@@ -293,20 +293,6 @@ int kii_object_init_upload_body(
 		const char* object_id,
 		char* out_upload_id);
 
-int kii_object_upload_at_once_with_reader(
-        kii_t* kii,
-        void* add_reader_context,
-        const kii_bucket_t* bucket,
-        kii_readers_t* readers,
-        char* out_object_id);
-
-int kii_object_upload_with_reader(
-        kii_t* kii,
-        void* add_reader_context,
-        const kii_bucket_t* bucket,
-        kii_readers_t* readers,
-        char* out_object_id);
-
 /** represents chunk data */
 typedef struct kii_chunk_data_t {
 	/** content-type of the body */
@@ -357,6 +343,22 @@ int kii_object_commit_upload(
 		const char* object_id,
 		const char* upload_id,
 		unsigned int commit);
+
+int kii_object_upload_body_at_once_with_reader(
+        kii_t* kii,
+        void* add_reader_context,
+        const kii_bucket_t* bucket,
+        const char* object_id,
+        const char* body_content_type,
+        kii_readers_t* readers);
+
+int kii_object_upload_body_with_reader(
+        kii_t* kii,
+        void* add_reader_context,
+        const kii_bucket_t* bucket,
+        const char* object_id,
+        kii_readers_t* readers,
+        size_t* out_sent_size);
 
 /** Download object body at one time.
  *  If the data size is large or unknown, consider use kii_object_download_body()

--- a/kii/kii.h
+++ b/kii/kii.h
@@ -106,6 +106,21 @@ typedef struct kii_t {
 
 } kii_t;
 
+typedef kii_bool_t (*KII_READER_OPEN_CB)(kii_t* kii, void* app_reader_context);
+typedef kii_bool_t (*KII_READER_READ_CB)(
+            kii_t* kii,
+            void* app_reader_context,
+            void* buff,
+            size_t buff_size,
+            size_t* out_size);
+typedef kii_bool_t (*KII_READER_CLOSE_CB)(kii_t* kii, void* app_reader_context);
+
+typedef struct kii_readers_t {
+    KII_READER_OPEN_CB open;
+    KII_READER_READ_CB read;
+    KII_READER_CLOSE_CB close;
+} kii_readers_t;
+
 /** Initializes Kii SDK
  *  \param [inout] kii sdk instance.
  *  \param [in] site the input of site name,
@@ -277,6 +292,20 @@ int kii_object_init_upload_body(
 		const kii_bucket_t* bucket,
 		const char* object_id,
 		char* out_upload_id);
+
+int kii_object_upload_at_once_with_reader(
+        kii_t* kii,
+        void* add_reader_context,
+        const kii_bucket_t* bucket,
+        kii_readers_t* readers,
+        char* out_object_id);
+
+int kii_object_upload_with_reader(
+        kii_t* kii,
+        void* add_reader_context,
+        const kii_bucket_t* bucket,
+        kii_readers_t* readers,
+        char* out_object_id);
 
 /** represents chunk data */
 typedef struct kii_chunk_data_t {

--- a/kii/kii_object.c
+++ b/kii/kii_object.c
@@ -429,6 +429,29 @@ exit:
     return ret;
 }
 
+int kii_object_upload_at_once_with_reader(
+        kii_t* kii,
+        void* add_reader_context,
+        const kii_bucket_t* bucket,
+        kii_readers_t* readers,
+        char* out_object_id)
+{
+    // TODO: implement me.
+    return 0;
+}
+
+
+int kii_object_upload_with_reader(
+        kii_t* kii,
+        void* add_reader_context,
+        const kii_bucket_t* bucket,
+        kii_readers_t* readers,
+        char* out_object_id)
+{
+    // TODO: implement me.
+    return 0;
+}
+
 int kii_object_commit_upload(
         kii_t* kii,
         const kii_bucket_t* bucket,

--- a/kii/kii_object.c
+++ b/kii/kii_object.c
@@ -429,29 +429,6 @@ exit:
     return ret;
 }
 
-int kii_object_upload_at_once_with_reader(
-        kii_t* kii,
-        void* add_reader_context,
-        const kii_bucket_t* bucket,
-        kii_readers_t* readers,
-        char* out_object_id)
-{
-    // TODO: implement me.
-    return 0;
-}
-
-
-int kii_object_upload_with_reader(
-        kii_t* kii,
-        void* add_reader_context,
-        const kii_bucket_t* bucket,
-        kii_readers_t* readers,
-        char* out_object_id)
-{
-    // TODO: implement me.
-    return 0;
-}
-
 int kii_object_commit_upload(
         kii_t* kii,
         const kii_bucket_t* bucket,
@@ -510,6 +487,30 @@ int kii_object_commit_upload(
     ret = 0;
 exit:
     return ret;
+}
+
+int kii_object_upload_body_at_once_with_reader(
+        kii_t* kii,
+        void* add_reader_context,
+        const kii_bucket_t* bucket,
+        const char* object_id,
+        const char* body_content_type,
+        kii_readers_t* readers)
+{
+    // TODO: implement me.
+    return 0;
+}
+
+int kii_object_upload_body_with_reader(
+        kii_t* kii,
+        void* add_reader_context,
+        const kii_bucket_t* bucket,
+        const char* object_id,
+        kii_readers_t* readers,
+        size_t* out_sent_size)
+{
+    // TODO: implement me.
+    return 0;
 }
 
 int kii_object_download_body_at_once(


### PR DESCRIPTION
アップロードAPIの追加です。

アプリケーションからデータを配列の形で貰わない方式です。
アプリケーションからデータを配列でもらわないので必要なメモリを少なくできます。

ボディのアップロードは画像が多くなると推測しています。画像の場合は不揮発性メモリ上に置かれる可能性が高いのでreaderを実装してもらってそこから読み出してもらった方がメモリ効率が良いです。
HTTP送信用のバッファに直接書き込めるので、スタックにしろヒープにしろ新しいメモリを確保する必要がなくなります。画像などはそれなりの大きさになると思われるので、結構省メモリになるのではと考えています。

Related issue: No913.
Release version: 1.1.6