### PR TITLE
Remove priority from kii push start routine

### DIFF
--- a/Linux/example.c
+++ b/Linux/example.c
@@ -288,7 +288,7 @@ int main(int argc, char** argv)
                 break;
             case 18:
                 printf("Initialize push\n");
-                kii_push_start_routine(&kii, 0, 0, received_callback);
+                kii_push_start_routine(&kii, received_callback);
                 while(1) {
                     sleep(1);
                 }

--- a/TI/CC3200/wlan_station/kii/example.c
+++ b/TI/CC3200/wlan_station/kii/example.c
@@ -236,7 +236,7 @@ int kiiDemo_test(void)
         UART_PRINT("failed!\r\n");
     }
     UART_PRINT("Initialize push\r\n");
-    kii_push_start_routine(&kii, DEMO_KII_PUSH_RECV_MSG_TASK_PRIO, DEMO_KII_PUSH_PINGREQ_TASK_PRIO, received_callback);
+    kii_push_start_routine(&kii, received_callback);
     return 0;
 }
 /* vim:set ts=4 sts=4 sw=4 et fenc=UTF-8 ff=unix: */

--- a/WinnerMicro/HED10W07SN/Src/Kii/example.c
+++ b/WinnerMicro/HED10W07SN/Src/Kii/example.c
@@ -238,7 +238,7 @@ int kiiDemo_test(char *buf)
         printf("failed!\n");
     }
     printf("Initialize push\n");
-    kii_push_start_routine(&kii, DEMO_KII_PUSH_RECV_MSG_TASK_PRIO, DEMO_KII_PUSH_PINGREQ_TASK_PRIO, received_callback);
+    kii_push_start_routine(&kii, received_callback);
     return 0;
 }
 /* vim:set ts=4 sts=4 sw=4 et fenc=UTF-8 ff=unix: */

--- a/gt202/kii_cloud_demo.c
+++ b/gt202/kii_cloud_demo.c
@@ -442,7 +442,7 @@ static int push()
 
         set_author(kii);
 
-        ret = kii_push_start_routine(kii, 0, 0, received_callback);
+        ret = kii_push_start_routine(kii, received_callback);
 
         printf("start_routine: %d\n", ret);
     }

--- a/kii/kii.h
+++ b/kii/kii.h
@@ -433,17 +433,11 @@ int kii_push_delete_topic(
  *  After succeeded, callback is called when push message is delivered to this
  *  thing.
  *  \param [inout] kii sdk instance.
- *  \param [in] task_priority task priority of receiving push.
- *  actual value is depends on the platform environment.
- *  \param [in] ping_req_task_priority task priority of sending ping to cloud.
- *  actual value is depends on the platform environment.
  *  \param [in] callback  callback function called when push message delivered. 
  *  \return 0:success, -1: failure
  */
 int kii_push_start_routine(
 		kii_t* kii,
-		unsigned int task_priority,
-		unsigned int ping_req_task_priority,
 		KII_PUSH_RECEIVED_CB callback);
 
 /** Execute server code.

--- a/kii/kii_push.c
+++ b/kii/kii_push.c
@@ -538,7 +538,7 @@ static void* kiiPush_pingReqTask(void* sdata)
 }
 #endif
 
-int kii_push_start_routine(kii_t* kii, unsigned int recvMsgtaskPrio, unsigned int pingReqTaskPrio, KII_PUSH_RECEIVED_CB callback)
+int kii_push_start_routine(kii_t* kii, KII_PUSH_RECEIVED_CB callback)
 {
     kii->push_received_cb = callback;
     kii->task_create_cb(KII_TASK_NAME_RECV_MSG,

--- a/tests/large_test/kii_test.cc
+++ b/tests/large_test/kii_test.cc
@@ -628,7 +628,7 @@ TEST(kiiTest, startRoutine)
     ASSERT_EQ(0, ret);
 
     printf("Z\n");fflush(stdout);
-    ret = kii_push_start_routine(&kii, 0, 0, received_callback);
+    ret = kii_push_start_routine(&kii, received_callback);
 
     ASSERT_EQ(0, ret);
 


### PR DESCRIPTION
KII_TASK_CREATEからPriority引数が無くなったため、kii_push_start_routineで要らなくなりました。
引数の削除とサンプルの修正を行いました。

Issue: #133 