### PR TITLE
Add a field to represent socket erro into kii_socket_context_t.

### DIFF
--- a/kii-core/kii_core.c
+++ b/kii-core/kii_core.c
@@ -153,7 +153,7 @@ prv_kii_http_execute(kii_core_t* kii)
             http_context->_socket_state = PRV_KII_SOCKET_STATE_CONNECT;
             http_context->_response_length = 0;
             http_context->_content_length_scanned = 0;
-            http_context->socket_context.default_http_client_error =
+            http_context->socket_context.http_error =
                 KII_HTTP_ERROR_NONE;
             return KII_HTTPC_AGAIN;
         case PRV_KII_SOCKET_STATE_CONNECT:
@@ -166,7 +166,7 @@ prv_kii_http_execute(kii_core_t* kii)
                     return KII_HTTPC_AGAIN;
                 default:
                     http_context->_socket_state = PRV_KII_SOCKET_STATE_IDLE;
-                    http_context->socket_context.default_http_client_error =
+                    http_context->socket_context.http_error =
                         KII_HTTP_ERROR_SOCKET;
                     return KII_HTTPC_FAIL;
             }
@@ -199,7 +199,7 @@ prv_kii_http_execute(kii_core_t* kii)
                     return KII_HTTPC_AGAIN;
                 default:
                     http_context->_socket_state = PRV_KII_SOCKET_STATE_IDLE;
-                    http_context->socket_context.default_http_client_error =
+                    http_context->socket_context.http_error =
                         KII_HTTP_ERROR_SOCKET;
                     return KII_HTTPC_FAIL;
             }
@@ -230,7 +230,7 @@ prv_kii_http_execute(kii_core_t* kii)
                     if (http_context->_received_size >=
                             http_context->buffer_size) {
                         M_KII_LOG("buffer is smaller than receiving data.");
-                        http_context->socket_context.default_http_client_error =
+                        http_context->socket_context.http_error =
                             KII_HTTP_ERROR_INSUFFICIENT_BUFFER;
                         return KII_HTTPC_FAIL;
                     }
@@ -270,7 +270,7 @@ prv_kii_http_execute(kii_core_t* kii)
                     return KII_HTTPC_AGAIN;
                 default:
                     http_context->_socket_state = PRV_KII_SOCKET_STATE_IDLE;
-                    http_context->socket_context.default_http_client_error =
+                    http_context->socket_context.http_error =
                         KII_HTTP_ERROR_SOCKET;
                     return KII_HTTPC_FAIL;
             }
@@ -288,7 +288,7 @@ prv_kii_http_execute(kii_core_t* kii)
                     int i = 0;
                     if (pointer == NULL) {
                         M_KII_LOG("invalid response.");
-                        http_context->socket_context.default_http_client_error =
+                        http_context->socket_context.http_error =
                             KII_HTTP_ERROR_INVALID_RESPONSE;
                         return KII_HTTPC_FAIL;
                     }
@@ -300,7 +300,7 @@ prv_kii_http_execute(kii_core_t* kii)
                         if (isdigit((int)pointer[i]) == 0) {
                             M_KII_LOG("invalid status code.");
                             kii->response_code = 0;
-                            http_context->socket_context.default_http_client_error =
+                            http_context->socket_context.http_error =
                                 KII_HTTP_ERROR_INVALID_RESPONSE;
                             return KII_HTTPC_FAIL;
                         }
@@ -321,7 +321,7 @@ prv_kii_http_execute(kii_core_t* kii)
                     return KII_HTTPC_AGAIN;
                 default:
                     http_context->_socket_state = PRV_KII_SOCKET_STATE_IDLE;
-                    http_context->socket_context.default_http_client_error =
+                    http_context->socket_context.http_error =
                         KII_HTTP_ERROR_SOCKET;
                     return KII_HTTPC_FAIL;
             }

--- a/kii-core/kii_core.c
+++ b/kii-core/kii_core.c
@@ -153,7 +153,8 @@ prv_kii_http_execute(kii_core_t* kii)
             http_context->_socket_state = PRV_KII_SOCKET_STATE_CONNECT;
             http_context->_response_length = 0;
             http_context->_content_length_scanned = 0;
-            http_context->socket_context.socket_error = KII_SOCKET_ERROR_NONE;
+            http_context->socket_context.default_http_client_error =
+                KII_DEFAULT_HTTP_CLIENT_ERROR_NONE;
             return KII_HTTPC_AGAIN;
         case PRV_KII_SOCKET_STATE_CONNECT:
             switch (http_context->connect_cb(&(http_context->socket_context),
@@ -165,8 +166,8 @@ prv_kii_http_execute(kii_core_t* kii)
                     return KII_HTTPC_AGAIN;
                 default:
                     http_context->_socket_state = PRV_KII_SOCKET_STATE_IDLE;
-                    http_context->socket_context.socket_error =
-                        KII_SOCKET_ERROR_SOCKET_FUNCTIONS;
+                    http_context->socket_context.default_http_client_error =
+                        KII_DEFAULT_HTTP_CLIENT_ERROR_SOCKET_FUNCTIONS;
                     return KII_HTTPC_FAIL;
             }
             /* This is programing error. */
@@ -198,8 +199,8 @@ prv_kii_http_execute(kii_core_t* kii)
                     return KII_HTTPC_AGAIN;
                 default:
                     http_context->_socket_state = PRV_KII_SOCKET_STATE_IDLE;
-                    http_context->socket_context.socket_error =
-                        KII_SOCKET_ERROR_SOCKET_FUNCTIONS;
+                    http_context->socket_context.default_http_client_error =
+                        KII_DEFAULT_HTTP_CLIENT_ERROR_SOCKET_FUNCTIONS;
                     return KII_HTTPC_FAIL;
             }
             /* This is programing error. */
@@ -229,8 +230,8 @@ prv_kii_http_execute(kii_core_t* kii)
                     if (http_context->_received_size >=
                             http_context->buffer_size) {
                         M_KII_LOG("buffer is smaller than receiving data.");
-                        http_context->socket_context.socket_error =
-                            KII_SOCKET_ERROR_RESPONSE_BUFFER_OVERFLOW;
+                        http_context->socket_context.default_http_client_error =
+                            KII_DEFAULT_HTTP_CLIENT_ERROR_RESPONSE_BUFFER_OVERFLOW;
                         return KII_HTTPC_FAIL;
                     }
                     if (http_context->_content_length_scanned != 1) {
@@ -269,8 +270,8 @@ prv_kii_http_execute(kii_core_t* kii)
                     return KII_HTTPC_AGAIN;
                 default:
                     http_context->_socket_state = PRV_KII_SOCKET_STATE_IDLE;
-                    http_context->socket_context.socket_error =
-                        KII_SOCKET_ERROR_SOCKET_FUNCTIONS;
+                    http_context->socket_context.default_http_client_error =
+                        KII_DEFAULT_HTTP_CLIENT_ERROR_SOCKET_FUNCTIONS;
                     return KII_HTTPC_FAIL;
             }
             /* This is programing error. */
@@ -287,8 +288,8 @@ prv_kii_http_execute(kii_core_t* kii)
                     int i = 0;
                     if (pointer == NULL) {
                         M_KII_LOG("invalid response.");
-                        http_context->socket_context.socket_error =
-                            KII_SOCKET_ERROR_INVALID_RESPONSE;
+                        http_context->socket_context.default_http_client_error =
+                            KII_DEFAULT_HTTP_CLIENT_ERROR_INVALID_RESPONSE;
                         return KII_HTTPC_FAIL;
                     }
 
@@ -299,8 +300,8 @@ prv_kii_http_execute(kii_core_t* kii)
                         if (isdigit((int)pointer[i]) == 0) {
                             M_KII_LOG("invalid status code.");
                             kii->response_code = 0;
-                            http_context->socket_context.socket_error =
-                                KII_SOCKET_ERROR_INVALID_RESPONSE;
+                            http_context->socket_context.default_http_client_error =
+                                KII_DEFAULT_HTTP_CLIENT_ERROR_INVALID_RESPONSE;
                             return KII_HTTPC_FAIL;
                         }
                         kii->response_code = (kii->response_code * 10) +
@@ -320,8 +321,8 @@ prv_kii_http_execute(kii_core_t* kii)
                     return KII_HTTPC_AGAIN;
                 default:
                     http_context->_socket_state = PRV_KII_SOCKET_STATE_IDLE;
-                    http_context->socket_context.socket_error =
-                        KII_SOCKET_ERROR_SOCKET_FUNCTIONS;
+                    http_context->socket_context.default_http_client_error =
+                        KII_DEFAULT_HTTP_CLIENT_ERROR_SOCKET_FUNCTIONS;
                     return KII_HTTPC_FAIL;
             }
             /* This is programing error. */

--- a/kii-core/kii_core.c
+++ b/kii-core/kii_core.c
@@ -153,6 +153,7 @@ prv_kii_http_execute(kii_core_t* kii)
             http_context->_socket_state = PRV_KII_SOCKET_STATE_CONNECT;
             http_context->_response_length = 0;
             http_context->_content_length_scanned = 0;
+            http_context->socket_context.socket_error = KII_SOCKET_ERROR_NONE;
             return KII_HTTPC_AGAIN;
         case PRV_KII_SOCKET_STATE_CONNECT:
             switch (http_context->connect_cb(&(http_context->socket_context),
@@ -164,6 +165,8 @@ prv_kii_http_execute(kii_core_t* kii)
                     return KII_HTTPC_AGAIN;
                 default:
                     http_context->_socket_state = PRV_KII_SOCKET_STATE_IDLE;
+                    http_context->socket_context.socket_error =
+                        KII_SOCKET_ERROR_SOCKET_FUNCTIONS;
                     return KII_HTTPC_FAIL;
             }
             /* This is programing error. */
@@ -195,6 +198,8 @@ prv_kii_http_execute(kii_core_t* kii)
                     return KII_HTTPC_AGAIN;
                 default:
                     http_context->_socket_state = PRV_KII_SOCKET_STATE_IDLE;
+                    http_context->socket_context.socket_error =
+                        KII_SOCKET_ERROR_SOCKET_FUNCTIONS;
                     return KII_HTTPC_FAIL;
             }
             /* This is programing error. */
@@ -224,6 +229,8 @@ prv_kii_http_execute(kii_core_t* kii)
                     if (http_context->_received_size >=
                             http_context->buffer_size) {
                         M_KII_LOG("buffer is smaller than receiving data.");
+                        http_context->socket_context.socket_error =
+                            KII_SOCKET_ERROR_RESPONSE_BUFFER_OVERFLOW;
                         return KII_HTTPC_FAIL;
                     }
                     if (http_context->_content_length_scanned != 1) {
@@ -262,6 +269,8 @@ prv_kii_http_execute(kii_core_t* kii)
                     return KII_HTTPC_AGAIN;
                 default:
                     http_context->_socket_state = PRV_KII_SOCKET_STATE_IDLE;
+                    http_context->socket_context.socket_error =
+                        KII_SOCKET_ERROR_SOCKET_FUNCTIONS;
                     return KII_HTTPC_FAIL;
             }
             /* This is programing error. */
@@ -278,6 +287,8 @@ prv_kii_http_execute(kii_core_t* kii)
                     int i = 0;
                     if (pointer == NULL) {
                         M_KII_LOG("invalid response.");
+                        http_context->socket_context.socket_error =
+                            KII_SOCKET_ERROR_INVALID_RESPONSE;
                         return KII_HTTPC_FAIL;
                     }
 
@@ -288,6 +299,8 @@ prv_kii_http_execute(kii_core_t* kii)
                         if (isdigit((int)pointer[i]) == 0) {
                             M_KII_LOG("invalid status code.");
                             kii->response_code = 0;
+                            http_context->socket_context.socket_error =
+                                KII_SOCKET_ERROR_INVALID_RESPONSE;
                             return KII_HTTPC_FAIL;
                         }
                         kii->response_code = (kii->response_code * 10) +
@@ -307,6 +320,8 @@ prv_kii_http_execute(kii_core_t* kii)
                     return KII_HTTPC_AGAIN;
                 default:
                     http_context->_socket_state = PRV_KII_SOCKET_STATE_IDLE;
+                    http_context->socket_context.socket_error =
+                        KII_SOCKET_ERROR_SOCKET_FUNCTIONS;
                     return KII_HTTPC_FAIL;
             }
             /* This is programing error. */

--- a/kii-core/kii_core.c
+++ b/kii-core/kii_core.c
@@ -154,7 +154,7 @@ prv_kii_http_execute(kii_core_t* kii)
             http_context->_response_length = 0;
             http_context->_content_length_scanned = 0;
             http_context->socket_context.default_http_client_error =
-                KII_DEFAULT_HTTP_CLIENT_ERROR_NONE;
+                KII_HTTP_ERROR_NONE;
             return KII_HTTPC_AGAIN;
         case PRV_KII_SOCKET_STATE_CONNECT:
             switch (http_context->connect_cb(&(http_context->socket_context),
@@ -167,7 +167,7 @@ prv_kii_http_execute(kii_core_t* kii)
                 default:
                     http_context->_socket_state = PRV_KII_SOCKET_STATE_IDLE;
                     http_context->socket_context.default_http_client_error =
-                        KII_DEFAULT_HTTP_CLIENT_ERROR_SOCKET_FUNCTIONS;
+                        KII_HTTP_ERROR_SOCKET;
                     return KII_HTTPC_FAIL;
             }
             /* This is programing error. */
@@ -200,7 +200,7 @@ prv_kii_http_execute(kii_core_t* kii)
                 default:
                     http_context->_socket_state = PRV_KII_SOCKET_STATE_IDLE;
                     http_context->socket_context.default_http_client_error =
-                        KII_DEFAULT_HTTP_CLIENT_ERROR_SOCKET_FUNCTIONS;
+                        KII_HTTP_ERROR_SOCKET;
                     return KII_HTTPC_FAIL;
             }
             /* This is programing error. */
@@ -231,7 +231,7 @@ prv_kii_http_execute(kii_core_t* kii)
                             http_context->buffer_size) {
                         M_KII_LOG("buffer is smaller than receiving data.");
                         http_context->socket_context.default_http_client_error =
-                            KII_DEFAULT_HTTP_CLIENT_ERROR_RESPONSE_BUFFER_OVERFLOW;
+                            KII_HTTP_ERROR_INSUFFICIENT_BUFFER;
                         return KII_HTTPC_FAIL;
                     }
                     if (http_context->_content_length_scanned != 1) {
@@ -271,7 +271,7 @@ prv_kii_http_execute(kii_core_t* kii)
                 default:
                     http_context->_socket_state = PRV_KII_SOCKET_STATE_IDLE;
                     http_context->socket_context.default_http_client_error =
-                        KII_DEFAULT_HTTP_CLIENT_ERROR_SOCKET_FUNCTIONS;
+                        KII_HTTP_ERROR_SOCKET;
                     return KII_HTTPC_FAIL;
             }
             /* This is programing error. */
@@ -289,7 +289,7 @@ prv_kii_http_execute(kii_core_t* kii)
                     if (pointer == NULL) {
                         M_KII_LOG("invalid response.");
                         http_context->socket_context.default_http_client_error =
-                            KII_DEFAULT_HTTP_CLIENT_ERROR_INVALID_RESPONSE;
+                            KII_HTTP_ERROR_INVALID_RESPONSE;
                         return KII_HTTPC_FAIL;
                     }
 
@@ -301,7 +301,7 @@ prv_kii_http_execute(kii_core_t* kii)
                             M_KII_LOG("invalid status code.");
                             kii->response_code = 0;
                             http_context->socket_context.default_http_client_error =
-                                KII_DEFAULT_HTTP_CLIENT_ERROR_INVALID_RESPONSE;
+                                KII_HTTP_ERROR_INVALID_RESPONSE;
                             return KII_HTTPC_FAIL;
                         }
                         kii->response_code = (kii->response_code * 10) +
@@ -322,7 +322,7 @@ prv_kii_http_execute(kii_core_t* kii)
                 default:
                     http_context->_socket_state = PRV_KII_SOCKET_STATE_IDLE;
                     http_context->socket_context.default_http_client_error =
-                        KII_DEFAULT_HTTP_CLIENT_ERROR_SOCKET_FUNCTIONS;
+                        KII_HTTP_ERROR_SOCKET;
                     return KII_HTTPC_FAIL;
             }
             /* This is programing error. */

--- a/kii-core/kii_socket_callback.h
+++ b/kii-core/kii_socket_callback.h
@@ -7,16 +7,16 @@
 extern "C" {
 #endif
 
-typedef enum kii_defaut_http_client_t {
+typedef enum kii_http_error_t {
     /** No error. */
-    KII_DEFAULT_HTTP_CLIENT_ERROR_NONE,
+    KII_HTTP_ERROR_NONE,
     /** Invalid response. */
-    KII_DEFAULT_HTTP_CLIENT_ERROR_INVALID_RESPONSE,
+    KII_HTTP_ERROR_INVALID_RESPONSE,
     /** Response buffer overflow. */
-    KII_DEFAULT_HTTP_CLIENT_ERROR_RESPONSE_BUFFER_OVERFLOW,
+    KII_HTTP_ERROR_INSUFFICIENT_BUFFER,
     /** Socket functions returns false. */
-    KII_DEFAULT_HTTP_CLIENT_ERROR_SOCKET_FUNCTIONS
-} kii_defaut_http_client_t;
+    KII_HTTP_ERROR_SOCKET
+} kii_http_error_t;
 
 typedef struct kii_socket_context_t {
     /** Application specific context object.
@@ -30,7 +30,7 @@ typedef struct kii_socket_context_t {
     int socket;
 
     /** Socket level error. */
-    kii_defaut_http_client_t default_http_client_error;
+    kii_http_error_t default_http_client_error;
 } kii_socket_context_t;
 
 typedef enum kii_socket_code_t {

--- a/kii-core/kii_socket_callback.h
+++ b/kii-core/kii_socket_callback.h
@@ -7,16 +7,16 @@
 extern "C" {
 #endif
 
-typedef enum kii_socket_error_t {
+typedef enum kii_defaut_http_client_t {
     /** No error. */
-    KII_SOCKET_ERROR_NONE,
+    KII_DEFAULT_HTTP_CLIENT_ERROR_NONE,
     /** Invalid response. */
-    KII_SOCKET_ERROR_INVALID_RESPONSE,
+    KII_DEFAULT_HTTP_CLIENT_ERROR_INVALID_RESPONSE,
     /** Response buffer overflow. */
-    KII_SOCKET_ERROR_RESPONSE_BUFFER_OVERFLOW,
+    KII_DEFAULT_HTTP_CLIENT_ERROR_RESPONSE_BUFFER_OVERFLOW,
     /** Socket functions returns false. */
-    KII_SOCKET_ERROR_SOCKET_FUNCTIONS
-} kii_socket_error_t;
+    KII_DEFAULT_HTTP_CLIENT_ERROR_SOCKET_FUNCTIONS
+} kii_defaut_http_client_t;
 
 typedef struct kii_socket_context_t {
     /** Application specific context object.
@@ -30,7 +30,7 @@ typedef struct kii_socket_context_t {
     int socket;
 
     /** Socket level error. */
-    kii_socket_error_t socket_error;
+    kii_defaut_http_client_t default_http_client_error;
 } kii_socket_context_t;
 
 typedef enum kii_socket_code_t {

--- a/kii-core/kii_socket_callback.h
+++ b/kii-core/kii_socket_callback.h
@@ -29,8 +29,8 @@ typedef struct kii_socket_context_t {
      */
     int socket;
 
-    /** Socket level error. */
-    kii_http_error_t default_http_client_error;
+    /** HTTP client error. */
+    kii_http_error_t http_error;
 } kii_socket_context_t;
 
 typedef enum kii_socket_code_t {

--- a/kii-core/kii_socket_callback.h
+++ b/kii-core/kii_socket_callback.h
@@ -7,6 +7,17 @@
 extern "C" {
 #endif
 
+typedef enum kii_socket_error_t {
+    /** No error. */
+    KII_SOCKET_ERROR_NONE,
+    /** Invalid response. */
+    KII_SOCKET_ERROR_INVALID_RESPONSE,
+    /** Response buffer overflow. */
+    KII_SOCKET_ERROR_RESPONSE_BUFFER_OVERFLOW,
+    /** Socket functions returns false. */
+    KII_SOCKET_ERROR_SOCKET_FUNCTIONS
+} kii_socket_error_t;
+
 typedef struct kii_socket_context_t {
     /** Application specific context object.
      * Used by socket callback implementations.
@@ -17,6 +28,9 @@ typedef struct kii_socket_context_t {
      * Used by socket callback implementations.
      */
     int socket;
+
+    /** Socket level error. */
+    kii_socket_error_t socket_error;
 } kii_socket_context_t;
 
 typedef enum kii_socket_code_t {

--- a/tests/large_test/kii_test.cc
+++ b/tests/large_test/kii_test.cc
@@ -150,6 +150,8 @@ TEST(kiiTest, objectWithID)
     initBucket(&bucket);
     strcpy(objectId, "my_object");
 
+    kii_object_delete(&kii, &bucket, objectId);
+
     kii.kii_core.response_code = 0;
     ret = kii_object_create_with_id(&kii, &bucket, objectId, "{}", NULL);
 
@@ -466,6 +468,8 @@ TEST(kiiTest, objectBodyOnce_binary)
     init(&kii, buffer, 4096);
     initBucket(&bucket);
     strcpy(objectId, "my_object");
+
+    kii_object_delete(&kii, &bucket, objectId);
 
     kii.kii_core.response_code = 0;
     ret = kii_object_create_with_id(&kii, &bucket, objectId, "{}", NULL);

--- a/tests/large_test/kii_test.cc
+++ b/tests/large_test/kii_test.cc
@@ -94,6 +94,8 @@ TEST(kiiTest, object)
     init(&kii, buffer, 4096);
     initBucket(&bucket);
 
+    kii_object_delete(&kii, &bucket, objectId);
+
     kii.kii_core.response_code = 0;
     memset(objectId, 0x00, KII_OBJECTID_SIZE + 1);
     ret = kii_object_create(&kii, &bucket, "{}", NULL, objectId);
@@ -149,6 +151,8 @@ TEST(kiiTest, objectWithID)
     init(&kii, buffer, 4096);
     initBucket(&bucket);
     strcpy(objectId, "my_object");
+
+    kii_object_delete(&kii, &bucket, objectId);
 
     kii.kii_core.response_code = 0;
     ret = kii_object_create_with_id(&kii, &bucket, objectId, "{}", NULL);
@@ -209,6 +213,8 @@ TEST(kiiTest, objectBodyOnce)
     initBucket(&bucket);
     strcpy(objectId, "my_object");
 
+    kii_object_delete(&kii, &bucket, objectId);
+
     kii.kii_core.response_code = 0;
     ret = kii_object_create_with_id(&kii, &bucket, objectId, "{}", NULL);
 
@@ -264,6 +270,8 @@ TEST(kiiTest, objectBodyMulti)
     init(&kii, buffer, 4096);
     initBucket(&bucket);
     strcpy(objectId, "my_object");
+
+    kii_object_delete(&kii, &bucket, objectId);
 
     kii.kii_core.response_code = 0;
     ret = kii_object_create_with_id(&kii, &bucket, objectId, "{}", NULL);
@@ -466,6 +474,8 @@ TEST(kiiTest, objectBodyOnce_binary)
     init(&kii, buffer, 4096);
     initBucket(&bucket);
     strcpy(objectId, "my_object");
+
+    kii_object_delete(&kii, &bucket, objectId);
 
     kii.kii_core.response_code = 0;
     ret = kii_object_create_with_id(&kii, &bucket, objectId, "{}", NULL);

--- a/tests/large_test/kii_test.cc
+++ b/tests/large_test/kii_test.cc
@@ -94,8 +94,6 @@ TEST(kiiTest, object)
     init(&kii, buffer, 4096);
     initBucket(&bucket);
 
-    kii_object_delete(&kii, &bucket, objectId);
-
     kii.kii_core.response_code = 0;
     memset(objectId, 0x00, KII_OBJECTID_SIZE + 1);
     ret = kii_object_create(&kii, &bucket, "{}", NULL, objectId);
@@ -151,8 +149,6 @@ TEST(kiiTest, objectWithID)
     init(&kii, buffer, 4096);
     initBucket(&bucket);
     strcpy(objectId, "my_object");
-
-    kii_object_delete(&kii, &bucket, objectId);
 
     kii.kii_core.response_code = 0;
     ret = kii_object_create_with_id(&kii, &bucket, objectId, "{}", NULL);
@@ -213,8 +209,6 @@ TEST(kiiTest, objectBodyOnce)
     initBucket(&bucket);
     strcpy(objectId, "my_object");
 
-    kii_object_delete(&kii, &bucket, objectId);
-
     kii.kii_core.response_code = 0;
     ret = kii_object_create_with_id(&kii, &bucket, objectId, "{}", NULL);
 
@@ -270,8 +264,6 @@ TEST(kiiTest, objectBodyMulti)
     init(&kii, buffer, 4096);
     initBucket(&bucket);
     strcpy(objectId, "my_object");
-
-    kii_object_delete(&kii, &bucket, objectId);
 
     kii.kii_core.response_code = 0;
     ret = kii_object_create_with_id(&kii, &bucket, objectId, "{}", NULL);
@@ -474,8 +466,6 @@ TEST(kiiTest, objectBodyOnce_binary)
     init(&kii, buffer, 4096);
     initBucket(&bucket);
     strcpy(objectId, "my_object");
-
-    kii_object_delete(&kii, &bucket, objectId);
 
     kii.kii_core.response_code = 0;
     ret = kii_object_create_with_id(&kii, &bucket, objectId, "{}", NULL);


### PR DESCRIPTION
thing-if ThingSDKにソケットのエラーを通知するため、`kii_socket_context_t`に`socket_error`というフィールドを追加しました。加えて、ソケットエラーの内容を表す`kii_socket_error_t` enumを追加しました。

### 何故必要か

現在、thing-if ThingSDKではtrait対応のため、新APIの設計と実装を行なっています。設計については
 KiiPlatform/thing-if-ThingSDK#80 で行なっています。

この設計中に各APIの失敗の詳細をアプリケーションに通知することになりました。その為に `kii_thing_if_error_reason_t ` というenumが追加されました。enumの詳細は[こちら](https://github.com/KiiPlatform/thing-if-ThingSDK/pull/80/files#diff-f006f00efd632cc83da07886aeeffe98R15)をご覧ください。このエラーの中に`KII_THING_IF_ERROR_REASON_SOCKET`というソケットレベルで失敗が発生したことを示す値を設定しました。

ソケットの実装はKiiThingIFSDK-Embedded-Coreの中にある為、thing-if ThingSDKの修正だけでは対応できません。その為、KiiThingSDK-Embedded-Coreレベルの修正が必要になりました。

### 修正方法の詳細

今回は、関数のシグネチャの変更は行わず、`kii_socket_context_t`にフィールドを追加する形で修正しました。関数が失敗を返した場合に、`kii_socket_context_t#socket_error`で失敗の詳細を確認します。この形の利点は以下の2つになります。

1. 後方互換性を確保出来る
1. socketを使わない実装の場合に対応出来る

2について詳しく説明します。KiiThingSDK-Embedded-CoreはHTTP通信部分をアプリケーション側で実装してもらいます。この際、socketを直接使った場合とsocketを直接使わず、curlなどのHTTPクライアントに任せる実装の2つを可能にしています。

関数のシグネチャを変更する形ですと、socketを使わない場合でもsocketのエラーが表面に現れてしまいます。これはアプリケーション開発者に混乱を招く可能性があります。このため、今回は`kii_socket_context_t`にフィールドを追加する形で対応しました。

ご検討よろしくおねがいします。