### PR TITLE
Imprv out params

### DIFF
--- a/kii/kii.c
+++ b/kii/kii.c
@@ -144,7 +144,7 @@ int kii_set_mqtt_cb_sock_close(kii_t* kii, KHC_CB_SOCK_CLOSE cb, void* userdata)
     return 0;
 }
 
-char* kii_get_etag(kii_t* kii) {
+const char* kii_get_etag(kii_t* kii) {
     return kii->_etag;
 }
 

--- a/kii/kii.h
+++ b/kii/kii.h
@@ -522,7 +522,7 @@ int kii_set_mqtt_cb_sock_send(kii_t* kii, KHC_CB_SOCK_SEND cb, void* userdata);
 int kii_set_mqtt_cb_sock_recv(kii_t* kii, KHC_CB_SOCK_RECV cb, void* userdata);
 int kii_set_mqtt_cb_sock_close(kii_t* kii, KHC_CB_SOCK_CLOSE cb, void* userdata);
 
-char* kii_get_etag(kii_t* kii);
+const char* kii_get_etag(kii_t* kii);
 
 int kii_get_resp_status(kii_t* kii);
 

--- a/kii/kii.h
+++ b/kii/kii.h
@@ -110,6 +110,14 @@ typedef struct kii_mqtt_endpoint_t {
     unsigned long ttl;
 } kii_mqtt_endpoint_t;
 
+typedef struct kii_object_id_t {
+    char id[64];
+} kii_object_id_t;
+
+typedef struct kii_installation_id_t {
+    char id[64];
+} kii_installation_id_t;
+
 struct kii_t;
 
 typedef void (*KII_PUSH_RECEIVED_CB)(
@@ -250,7 +258,7 @@ kii_code_t kii_post_object(
 		const kii_bucket_t* bucket,
 		const char* object_data,
 		const char* object_content_type,
-		char* out_object_id);
+		kii_object_id_t* out_object_id);
 
 /** Create new object with the specified ID
  *  \param [inout] kii sdk instance.
@@ -406,8 +414,7 @@ kii_code_t kii_delete_topic(
 kii_code_t kii_install_push(
         kii_t* kii,
         kii_bool_t development,
-        char* installation_id,
-        size_t installation_id_len);
+        kii_installation_id_t* out_installation_id);
 
 kii_code_t kii_get_mqtt_endpoint(
     kii_t* kii,

--- a/kii/kii_mqtt.c
+++ b/kii/kii_mqtt.c
@@ -427,11 +427,9 @@ void* _mqtt_start_recvmsg_task(void* sdata)
         {
             case KII_MQTT_PREPARING_ENDPOINT:
                 {
-                    char installation_id[KII_PUSH_INSTALLATIONID_SIZE + 1];
+                    kii_installation_id_t ins_id;
 
-                    if(kii_install_push(kii, KII_FALSE, installation_id,
-                                    sizeof(installation_id) /
-                                        sizeof(installation_id[0])) != KII_ERR_OK)
+                    if(kii_install_push(kii, KII_FALSE, &ins_id) != KII_ERR_OK)
                     {
                         M_KII_LOG(kii->kii_core.logger_cb(
                                 "kii-error: mqtt installation error\r\n"));
@@ -444,7 +442,7 @@ void* _mqtt_start_recvmsg_task(void* sdata)
                     do
                     {
                         kii->delay_ms_cb(1000);
-                        get_ep_res = kii_get_mqtt_endpoint(kii, installation_id,
+                        get_ep_res = kii_get_mqtt_endpoint(kii, ins_id.id,
                                 &endpoint);
                         if (get_ep_res == KII_ERR_OK) {
                             retry = 0;
@@ -467,7 +465,7 @@ void* _mqtt_start_recvmsg_task(void* sdata)
                     pushState = KII_MQTT_SUBSCRIBING_TOPIC;
 
                     M_KII_LOG(kii->kii_core.logger_cb("installationID:%s\r\n",
-                                    installation_id));
+                                    ins_id.id));
                     M_KII_LOG(kii->kii_core.logger_cb("mqttTopic:%s\r\n",
                                     endpoint.topic));
                     M_KII_LOG(kii->kii_core.logger_cb("host:%s\r\n",

--- a/kii/kii_object.c
+++ b/kii/kii_object.c
@@ -12,7 +12,7 @@ kii_code_t kii_post_object(
         const kii_bucket_t* bucket,
         const char* object_data,
         const char* object_content_type,
-        char* out_object_id)
+        kii_object_id_t* out_object_id)
 {
     khc_set_zero_excl_cb(&kii->_khc);
     _reset_buff(kii);
@@ -43,8 +43,8 @@ kii_code_t kii_post_object(
     memset(fields, 0, sizeof(fields));
     fields[0].name = "objectID";
     fields[0].type = KII_JSON_FIELD_TYPE_STRING;
-    fields[0].field_copy.string = out_object_id;
-    fields[0].field_copy_buff_size = KII_OBJECTID_SIZE + 1;
+    fields[0].field_copy.string = out_object_id->id;
+    fields[0].field_copy_buff_size = sizeof(out_object_id->id);
     fields[1].name = NULL;
 
     result = prv_kii_json_read_object(kii, buff, buff_size, fields);

--- a/kii/kii_push.c
+++ b/kii/kii_push.c
@@ -131,8 +131,7 @@ exit:
 kii_code_t kii_install_push(
         kii_t* kii,
         kii_bool_t development,
-        char* installation_id,
-        size_t installation_id_len)
+        kii_installation_id_t* out_installation_id)
 {
     khc_set_zero_excl_cb(&kii->_khc);
     _reset_buff(kii);
@@ -160,8 +159,8 @@ kii_code_t kii_install_push(
     memset(fields, 0, sizeof(fields));
     fields[0].name = "installationID";
     fields[0].type = KII_JSON_FIELD_TYPE_STRING;
-    fields[0].field_copy.string = installation_id;
-    fields[0].field_copy_buff_size = installation_id_len;
+    fields[0].field_copy.string = out_installation_id->id;
+    fields[0].field_copy_buff_size = sizeof(out_installation_id->id);
     fields[1].name = NULL;
 
     parse_result = prv_kii_json_read_object(kii, buff, buff_size, fields);

--- a/tests/large_test/object_test.cpp
+++ b/tests/large_test/object_test.cpp
@@ -51,7 +51,7 @@ TEST_CASE("Object Tests")
             REQUIRE( post_res == KII_ERR_OK );
             REQUIRE( khc_get_status_code(&kii._khc) == 201 );
             REQUIRE( strlen(object_id) > 0 );
-            char* etag = kii_get_etag(&kii);
+            const char* etag = kii_get_etag(&kii);
             size_t etag_len = strlen(etag);
             REQUIRE( etag_len == 3 );
 
@@ -73,7 +73,7 @@ TEST_CASE("Object Tests")
                 REQUIRE( patch_res == KII_ERR_OK );
                 REQUIRE( khc_get_status_code(&kii._khc) == 200 );
 
-                char* p_etag = kii_get_etag(&kii);
+                const char* p_etag = kii_get_etag(&kii);
                 size_t p_etag_len = strlen(etag);
                 char p_etag_copy[p_etag_len+1];
                 memcpy(p_etag_copy, p_etag, p_etag_len);

--- a/tests/large_test/object_test.cpp
+++ b/tests/large_test/object_test.cpp
@@ -44,13 +44,12 @@ TEST_CASE("Object Tests")
         SECTION("POST") {
             std::this_thread::sleep_for(std::chrono::milliseconds(200));
             const char object[] = "{}";
-            char object_id[128];
-            object_id[0] = '\0';
-            kii_code_t post_res = kii_post_object(&kii, &bucket, object, NULL, object_id);
+            kii_object_id_t obj_id;
+            kii_code_t post_res = kii_post_object(&kii, &bucket, object, NULL, &obj_id);
 
             REQUIRE( post_res == KII_ERR_OK );
             REQUIRE( khc_get_status_code(&kii._khc) == 201 );
-            REQUIRE( strlen(object_id) > 0 );
+            REQUIRE( strlen(obj_id.id) > 0 );
             const char* etag = kii_get_etag(&kii);
             size_t etag_len = strlen(etag);
             REQUIRE( etag_len == 3 );
@@ -59,17 +58,17 @@ TEST_CASE("Object Tests")
                 char etag_copy[etag_len+1];
                 memcpy(etag_copy, etag, etag_len);
                 etag_copy[etag_len] = '\0';
-                kii_code_t put_res = kii_put_object(&kii, &bucket, object_id, object, NULL, etag_copy);
+                kii_code_t put_res = kii_put_object(&kii, &bucket, obj_id.id, object, NULL, etag_copy);
                 REQUIRE( put_res == KII_ERR_OK );
                 REQUIRE( khc_get_status_code(&kii._khc) == 200 );
                 // Now etag_copy should be obsoleted.
-                put_res = kii_put_object(&kii, &bucket, object_id, object, NULL, etag_copy);
+                put_res = kii_put_object(&kii, &bucket, obj_id.id, object, NULL, etag_copy);
                 REQUIRE( put_res == KII_ERR_RESP_STATUS );
                 REQUIRE( khc_get_status_code(&kii._khc) == 409 );
             }
             SECTION("PATCH") {
                 const char patch_data[] = "{\"patch\":1}";
-                kii_code_t patch_res = kii_patch_object(&kii, &bucket, object_id, patch_data, NULL);
+                kii_code_t patch_res = kii_patch_object(&kii, &bucket, obj_id.id, patch_data, NULL);
                 REQUIRE( patch_res == KII_ERR_OK );
                 REQUIRE( khc_get_status_code(&kii._khc) == 200 );
 
@@ -79,16 +78,16 @@ TEST_CASE("Object Tests")
                 memcpy(p_etag_copy, p_etag, p_etag_len);
                 p_etag_copy[p_etag_len] = '\0';
 
-                patch_res = kii_patch_object(&kii, &bucket, object_id, patch_data, p_etag_copy);
+                patch_res = kii_patch_object(&kii, &bucket, obj_id.id, patch_data, p_etag_copy);
                 REQUIRE( patch_res == KII_ERR_OK );
                 REQUIRE( khc_get_status_code(&kii._khc) == 200 );
                 // Now p_etag_copy is not valid.
-                patch_res = kii_patch_object(&kii, &bucket, object_id, patch_data, p_etag_copy);
+                patch_res = kii_patch_object(&kii, &bucket, obj_id.id, patch_data, p_etag_copy);
                 REQUIRE( patch_res == KII_ERR_RESP_STATUS );
                 REQUIRE( khc_get_status_code(&kii._khc) == 409 );
             }
             SECTION("GET") {
-                kii_code_t get_res = kii_get_object(&kii, &bucket, object_id);
+                kii_code_t get_res = kii_get_object(&kii, &bucket, obj_id.id);
                 REQUIRE( get_res == KII_ERR_OK );
                 REQUIRE( khc_get_status_code(&kii._khc) == 200 );
 
@@ -98,16 +97,16 @@ TEST_CASE("Object Tests")
                 REQUIRE ( err_str.empty() );
                 REQUIRE ( v.is<picojson::object>() );
                 picojson::object obj = v.get<picojson::object>();
-                auto obj_id = obj.at("_id");
-                REQUIRE ( obj_id.is<std::string>() );
-                REQUIRE ( obj_id.get<std::string>() == std::string(object_id) );
+                auto obj_id_ = obj.at("_id");
+                REQUIRE ( obj_id_.is<std::string>() );
+                REQUIRE ( obj_id_.get<std::string>() == std::string(obj_id.id) );
             }
             SECTION("DELETE") {
-                kii_code_t delete_res = kii_delete_object(&kii, &bucket, object_id);
+                kii_code_t delete_res = kii_delete_object(&kii, &bucket, obj_id.id);
                 REQUIRE( delete_res == KII_ERR_OK );
                 REQUIRE( khc_get_status_code(&kii._khc) == 204 );
                 // Now get should return 404.
-                kii_code_t get_res = kii_get_object(&kii, &bucket, object_id);
+                kii_code_t get_res = kii_get_object(&kii, &bucket, obj_id.id);
                 REQUIRE( get_res == KII_ERR_RESP_STATUS );
                 REQUIRE( khc_get_status_code(&kii._khc) == 404 );
             }
@@ -123,7 +122,7 @@ TEST_CASE("Object Tests")
                 };
                 kiiltest::BodyFunc ctx;
                 ctx.on_read = on_read;
-                kii_code_t upload_res = kii_upload_object_body(&kii, &bucket, object_id, "text/plain", body.length(), kiiltest::read_cb, &ctx);
+                kii_code_t upload_res = kii_upload_object_body(&kii, &bucket, obj_id.id, "text/plain", body.length(), kiiltest::read_cb, &ctx);
                 REQUIRE( khc_get_status_code(&kii._khc) == 200 );
                 REQUIRE( upload_res == KII_ERR_OK );
 
@@ -136,7 +135,7 @@ TEST_CASE("Object Tests")
                     return size * count;
                 };
                 ctx.on_write = on_write;
-                kii_code_t download_res = kii_download_object_body(&kii, &bucket, object_id, kiiltest::write_cb, &ctx);
+                kii_code_t download_res = kii_download_object_body(&kii, &bucket, obj_id.id, kiiltest::write_cb, &ctx);
                 REQUIRE( khc_get_status_code(&kii._khc) == 200 );
                 REQUIRE( download_res == KII_ERR_OK );
                 REQUIRE ( oss.str() == body );

--- a/tests/large_test/push_test.cpp
+++ b/tests/large_test/push_test.cpp
@@ -36,9 +36,8 @@ TEST_CASE("Push Tests")
 
         // Post object to create bucket.
         const char object[] = "{}";
-        char object_id[128];
-        object_id[0] = '\0';
-        kii_code_t post_res = kii_post_object(&kii, &bucket, object, NULL, object_id);
+        kii_object_id_t obj_id;
+        kii_code_t post_res = kii_post_object(&kii, &bucket, object, NULL, &obj_id);
         CHECK(post_res == KII_ERR_OK);
         REQUIRE(khc_get_status_code(&kii._khc) == 201);
 
@@ -107,12 +106,11 @@ TEST_CASE("Push Tests")
         }
     }
     SECTION("Install push") {
-        char installation_id[64];
-        installation_id[0] = '\0';
-        kii_code_t ins_res = kii_install_push(&kii, KII_TRUE, installation_id, 64);
+        kii_installation_id_t ins_id;
+        kii_code_t ins_res = kii_install_push(&kii, KII_TRUE, &ins_id);
         CHECK(ins_res == KII_ERR_OK);
         REQUIRE(khc_get_status_code(&kii._khc) == 201);
-        REQUIRE(strlen(installation_id) > 0);
+        REQUIRE(strlen(ins_id.id) > 0);
 
         SECTION("Get MQTT endpoint") {
             kii_mqtt_endpoint_t endpoint;
@@ -122,7 +120,7 @@ TEST_CASE("Push Tests")
             kii_code_t get_ep_res = KII_ERR_FAIL;
             do {
                 std::this_thread::sleep_for(std::chrono::milliseconds(200));
-                get_ep_res = kii_get_mqtt_endpoint(&kii, installation_id, &endpoint);
+                get_ep_res = kii_get_mqtt_endpoint(&kii, ins_id.id, &endpoint);
                 status = khc_get_status_code(&kii._khc);
             } while (status == 503);
 


### PR DESCRIPTION
Improved out string parameters in API.

- Put fixed length char array in the struct so that SDK can determine the size of buffer needed. Since app developer can't determine the size of buffer unless spec of the length limitation is defined.