### PR TITLE
fix logic to check end of recv

### DIFF
--- a/kii-core/kii_core.c
+++ b/kii-core/kii_core.c
@@ -256,7 +256,7 @@ prv_kii_http_execute(kii_core_t* kii)
                             '\0';
                         http_context->_socket_state =
                             PRV_KII_SOCKET_STATE_CLOSE;
-                    } else if (actualLength < size) {
+                    } else if (actualLength == 0) {
                         /* If content-length is not present, wait for
                          * Connnection is closed by server.
                          */

--- a/kii-core/linux/kii_core_secure_socket.c
+++ b/kii-core/linux/kii_core_secure_socket.c
@@ -128,13 +128,21 @@ kii_socket_code_t
 {
     ssl_context_t* ctx = (ssl_context_t*)socket_context->app_context;
     int ret = SSL_read(ctx->ssl, buffer, length_to_read);
+    *out_actual_length = 0;
     if (ret > 0) {
         *out_actual_length = ret;
         return KII_SOCKETC_OK;
+    } else if (ret == 0 ) {
+        int ssl_error = SSL_get_error(ctx->ssl, ret);
+        if (ssl_error == SSL_ERROR_ZERO_RETURN) {
+            return KII_SOCKETC_OK;
+        } else if (ssl_error == SSL_ERROR_WANT_READ || ssl_error == SSL_ERROR_WANT_WRITE) {
+            return KII_SOCKETC_AGAIN;
+        } else {
+            return KII_SOCKETC_FAIL;
+        }
+        return KII_SOCKETC_FAIL;
     } else {
-        printf("failed to receive:\n");
-        /* TOOD: could be 0 on success? */
-        *out_actual_length = 0;
         return KII_SOCKETC_FAIL;
     }
 }


### PR DESCRIPTION
### Brief 
Found issue that when download object body, size of dowloaded body was smaller than actual size time to time. 
### Changes
- fix logic when check end of receiving. 