### PR TITLE
Add API to upload thing state

### DIFF
--- a/kii-core/kii_core.c
+++ b/kii-core/kii_core.c
@@ -1404,15 +1404,12 @@ prv_set_mqtt_endpoint_path(kii_core_t* kii, const char* installation_id)
             kii->app_id,
             installation_id);
 }
-    static void
-prv_set_thing_if_path(
-    kii_core_t* kii,
-    const char* thing_id)
+void prv_set_thing_if_path(kii_core_t* kii, const char* thing_id)
 {
     kii_sprintf(kii->_http_request_path,
-    "thing-if/apps/%s/targets/thing:%s",
-    kii->app_id,
-    thing_id);
+        "thing-if/apps/%s/targets/thing:%s",
+        kii->app_id,
+        thing_id);
 }
     kii_error_code_t
 kii_core_install_thing_push(

--- a/kii-core/kii_core.h
+++ b/kii-core/kii_core.h
@@ -563,8 +563,7 @@ kii_core_upload_thing_state(
         const char* thing_id,
         const char* state,
         const char* content_type,
-        const char* content_encoding,
-        const char* normalizer_host);
+        const char* content_encoding);
 
 /** prepare request of create object.
  * after this method succeeded, state of SDK becomes KII_STATE_READY.<br>

--- a/kii-core/kii_core.h
+++ b/kii-core/kii_core.h
@@ -368,7 +368,7 @@ typedef struct kii_core_t
      * value is set by implementation of KII_HTTPCB_EXECUTE
      */
     int response_code;
-    /** HTTP response body 
+    /** HTTP response body
      * value is set by implementation of KII_HTTPCB_EXECUTE
      */
     char* response_body;
@@ -555,6 +555,14 @@ kii_error_code_t
 kii_core_thing_authentication(kii_core_t* kii,
         const char* vendor_thing_id,
         const char* password);
+
+kii_error_code_t
+kii_core_upload_thing_state(
+        kii_core_t* kii,
+        const char* thing_id,
+        const char* state,
+        const char* content_type,
+        const char* encoding);
 
 /** prepare request of create object.
  * after this method succeeded, state of SDK becomes KII_STATE_READY.<br>

--- a/kii-core/kii_core.h
+++ b/kii-core/kii_core.h
@@ -160,6 +160,7 @@ typedef struct kii_http_context_t
      */
     const char* host;
 
+    const char* normalizer_host;
     /** socket context used by the http client
      *
      * This field becomes activate, if KII_USE_CUSTOM_HTTP_CLIENT is not
@@ -562,7 +563,8 @@ kii_core_upload_thing_state(
         const char* thing_id,
         const char* state,
         const char* content_type,
-        const char* encoding);
+        const char* content_encoding,
+        const char* normalizer_host);
 
 /** prepare request of create object.
  * after this method succeeded, state of SDK becomes KII_STATE_READY.<br>

--- a/kii-core/linux/kii_core_init.c
+++ b/kii-core/linux/kii_core_init.c
@@ -35,6 +35,7 @@ void kii_core_impl_init(
     http_ctx->recv_cb = s_recv_cb;
     http_ctx->close_cb = s_close_cb;
     http_ctx->socket_context.app_context = NULL;
+    http_ctx->normalizer_host = NULL;
 
     kii->logger_cb = logger_cb;
 }

--- a/kii/kii.h
+++ b/kii/kii.h
@@ -153,6 +153,13 @@ int kii_thing_register(
 		const char* thing_type,
 		const char* password);
 
+int kii_thing_upload_state(
+		kii_t* kii,
+		const char* thing_id,
+		const char* thing_state,
+		const char* content_type,
+		const char* encoding);
+
 /** Create new object
  *  \param [inout] kii sdk instance.
  *  \param [in] bucket specify the bucket of which object is stored.
@@ -438,7 +445,7 @@ int kii_push_delete_topic(
  *  After succeeded, callback is called when push message is delivered to this
  *  thing.
  *  \param [inout] kii sdk instance.
- *  \param [in] callback  callback function called when push message delivered. 
+ *  \param [in] callback  callback function called when push message delivered.
  *  \return 0:success, -1: failure
  */
 int kii_push_start_routine(

--- a/kii/kii.h
+++ b/kii/kii.h
@@ -158,7 +158,8 @@ int kii_thing_upload_state(
 		const char* thing_id,
 		const char* thing_state,
 		const char* content_type,
-		const char* encoding);
+		const char* content_encoding,
+		const char* normalizer_host);
 
 /** Create new object
  *  \param [inout] kii sdk instance.

--- a/kii/kii_thing.c
+++ b/kii/kii_thing.c
@@ -157,7 +157,8 @@ int kii_thing_upload_state(
         const char* thing_id,
         const char* thing_state,
         const char* content_type,
-        const char* encoding)
+        const char* content_encoding,
+        const char* normalizer_host)
 {
     char* buf = NULL;
     size_t buf_size = 0;

--- a/kii/kii_thing.c
+++ b/kii/kii_thing.c
@@ -168,12 +168,16 @@ int kii_thing_upload_state(
     kii_json_field_t fields[3];
     kii_json_parse_result_t result;
 
+    if (normalizer_host != NULL) {
+        kii->kii_core.http_context.normalizer_host = normalizer_host;
+    }
+
     core_err = kii_core_upload_thing_state(
         &kii->kii_core,
         thing_id,
         thing_state,
         content_type,
-        encoding);
+        content_encoding);
     if (core_err != KIIE_OK) {
         goto exit;
     }

--- a/kii/kii_thing.c
+++ b/kii/kii_thing.c
@@ -111,7 +111,7 @@ int kii_thing_register(
         goto exit;
     }
     do {
-        core_err = kii_core_run(&kii->kii_core); 
+        core_err = kii_core_run(&kii->kii_core);
         state = kii_core_get_state(&kii->kii_core);
     } while (state != KII_STATE_IDLE);
     if (core_err != KIIE_OK) {
@@ -144,6 +144,46 @@ int kii_thing_register(
     result = prv_kii_json_read_object(kii, buf, buf_size, fields);
     if (result != KII_JSON_PARSE_SUCCESS) {
         ret = -1;
+        goto exit;
+    }
+    ret = 0;
+
+exit:
+    return ret;
+}
+
+int kii_thing_upload_state(
+        kii_t* kii,
+        const char* thing_id,
+        const char* thing_state,
+        const char* content_type,
+        const char* encoding)
+{
+    char* buf = NULL;
+    size_t buf_size = 0;
+    int ret = -1;
+    kii_error_code_t core_err;
+    kii_state_t state;
+    kii_json_field_t fields[3];
+    kii_json_parse_result_t result;
+
+    core_err = kii_core_upload_thing_state(
+        &kii->kii_core,
+        thing_id,
+        thing_state,
+        content_type,
+        encoding);
+    if (core_err != KIIE_OK) {
+        goto exit;
+    }
+    do {
+        core_err = kii_core_run(&kii->kii_core);
+        state = kii_core_get_state(&kii->kii_core);
+    } while (state != KII_STATE_IDLE);
+    if (core_err != KIIE_OK) {
+        goto exit;
+    }
+    if(kii->kii_core.response_code < 200 || 300 <= kii->kii_core.response_code) {
         goto exit;
     }
     ret = 0;

--- a/kii/kii_thing.c
+++ b/kii/kii_thing.c
@@ -190,6 +190,7 @@ int kii_thing_upload_state(
     ret = 0;
 
 exit:
+    kii->kii_core.http_context.normalizer_host = NULL;
     return ret;
 }
 /* vim:set ts=4 sts=4 sw=4 et fenc=UTF-8 ff=unix: */


### PR DESCRIPTION
This PR is more focus on how the new API looks like. Completed implementation and test will be another PR. 
- Application should be able to use new api to upload normal state(json format). 
- Application should be able to use new api to upload binary state(like gzip format).
## Changes

- Add API: `kii_thing_upload_state`

## How to use
1. upload json format state

```
int result = kii_thing_upload_state(
        &kii,
        "th.dummdy-id",
        "{\"Alias\":{\"Temperature\":34}}",
        NULL,
        NULL,
        NULL);
```

2. upload binary state

```
int result = kii_thing_upload_state(
        &kii,
        "th.dummdy-id",
        binaryData,
        "application/json",
        "gzip",
        "custom-endpoint-kii.com");
```